### PR TITLE
Check auth endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+secrets.properties
+
 .vscode
 
 .idea/

--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthCheckerInterface.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthCheckerInterface.java
@@ -1,0 +1,17 @@
+/**
+ * Defines functions for extracting the details of authenticated user.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.authentication;
+
+import org.springframework.security.core.Authentication;
+
+import java.util.Map;
+
+public interface AuthCheckerInterface {
+    Map<String, String> getDefaultResponse();
+    boolean isAuthenticated(Authentication authentication);
+    String getAuthUserEmail(Authentication authentication);
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
@@ -1,0 +1,58 @@
+/**
+ * This controller handles an authentication-related endpoint for the application.
+ * The `/check-auth` endpoint checks whether a user is authenticated or not and their user role
+ * and returns a JSON response accordingly.
+ *
+ * @author Natalie Jungquist
+ */
+
+// TODO : NOTE THIS IS CURRENTLY A CLASS STUB. ITS TESTS AND FUNCTIONS HAVE NOT BEEN IMPLEMENTED
+
+package COMP_49X_our_search.backend.authentication;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@RestController
+public class AuthController {
+
+    private final OAuthChecker OAuthChecker;
+
+    public AuthController(OAuthChecker OAuthChecker) {
+        this.OAuthChecker = OAuthChecker;
+    }
+
+    @GetMapping("/check-auth")
+    public ResponseEntity<Map<String, String>> checkAuthStatus() {
+
+        Map<String, String> response = OAuthChecker.getDefaultResponse();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (OAuthChecker.isAuthenticated(authentication)) {
+            response.put("isAuthenticated", "true");
+
+            String email = OAuthChecker.getAuthUserEmail(authentication);
+            System.out.println("email: " + email);
+
+            // TODO check db if they already exist based on the email. returning a default value for now
+            response.put("isStudent", "true");
+//            response.put("isFaculty", "true");
+//            response.put("isAdmin", "true");
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    @RequestMapping("/invalid-email")
+    public String invalidEmail() {
+        return "forward:invalid-email.html";
+    }
+
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
@@ -49,10 +49,4 @@ public class AuthController {
 
         return ResponseEntity.ok(response);
     }
-
-    @RequestMapping("/invalid-email")
-    public String invalidEmail() {
-        return "forward:invalid-email.html";
-    }
-
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/OAuthChecker.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/OAuthChecker.java
@@ -1,0 +1,46 @@
+/**
+ * Implementation responsible for handling authentication-related utility functions.
+ * Specifically for OAuth2 users.
+ *  - Check if a user is authenticated.
+ *  - Retrieve the authenticated user's email.
+ *  - Provide a default authentication response structure.
+ */
+
+package COMP_49X_our_search.backend.authentication;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class OAuthChecker implements AuthCheckerInterface {
+
+    @Override
+    public Map<String, String> getDefaultResponse() {
+        Map<String, String> response = new HashMap<>();
+        response.put("isAuthenticated", "false");
+        response.put("isStudent", "false");
+        response.put("isFaculty", "false");
+        response.put("isAdmin", "false");
+        return response;
+    }
+
+    @Override
+    public boolean isAuthenticated(Authentication authentication) {
+        return authentication instanceof OAuth2AuthenticationToken;
+    }
+
+    @Override
+    public String getAuthUserEmail(Authentication authentication) {
+        if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+            OAuth2User user = oauthToken.getPrincipal();
+            Map<String, Object> attributes = user.getAttributes();
+            return (attributes != null && attributes.containsKey("email")) ? attributes.get("email").toString() : "";
+        }
+        return "";
+    }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/OAuthChecker.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/OAuthChecker.java
@@ -36,7 +36,8 @@ public class OAuthChecker implements AuthCheckerInterface {
 
     @Override
     public String getAuthUserEmail(Authentication authentication) {
-        if (authentication instanceof OAuth2AuthenticationToken oauthToken) {
+        if (authentication instanceof OAuth2AuthenticationToken) {
+            OAuth2AuthenticationToken oauthToken = (OAuth2AuthenticationToken) authentication;
             OAuth2User user = oauthToken.getPrincipal();
             Map<String, Object> attributes = user.getAttributes();
             return (attributes != null && attributes.containsKey("email")) ? attributes.get("email").toString() : "";

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerIntegrationTest.java
@@ -1,0 +1,98 @@
+/**
+ * Integration tests for the endpoint that responds with information about the app's current
+ * authentication status. Tests that the endpoint returns expected responses based on if the
+ * app is authenticated with a user and the user's role.
+ * 
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.authentication;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class AuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OAuthChecker mockOAuthChecker;
+
+    @BeforeEach
+    void setUp() {
+        Map<String, String> responseBeforeModification = new HashMap<>();
+        responseBeforeModification.put("isAuthenticated", "false");
+        responseBeforeModification.put("isStudent", "false");
+        responseBeforeModification.put("isFaculty", "false");
+        responseBeforeModification.put("isAdmin", "false");
+
+        when(mockOAuthChecker.getDefaultResponse()).thenReturn(responseBeforeModification);
+    }
+
+    @Test
+    void testCheckAuthStatus_Unauthenticated() throws Exception {
+        when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(false);
+
+        mockMvc.perform(get("/check-auth"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthenticated").value("false"))
+                .andExpect(jsonPath("$.isStudent").value("false"))
+                .andExpect(jsonPath("$.isFaculty").value("false"))
+                .andExpect(jsonPath("$.isAdmin").value("false"));
+    }
+
+    @Test
+    void testCheckAuthStatus_AuthenticatedStudent() throws Exception {
+        when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(true);
+        when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn("test@sandiego.edu");
+        //when(...get user role...).thenReturn(...student...); //TODO method
+
+        mockMvc.perform(get("/check-auth"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthenticated").value("true"))
+                .andExpect(jsonPath("$.isStudent").value("true"));
+    }
+
+    // TODO the below tests will be executed once the method to check the DB for user role is completed
+//    @Test
+//    void testCheckAuthStatus_AuthenticatedAdmin() throws Exception {
+//        when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(true);
+//        when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn("test@sandiego.edu");
+//        //when(...get user role...).thenReturn(...admin...); //TODO method
+//
+//        mockMvc.perform(get("/check-auth"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.isAuthenticated").value("true"))
+//                .andExpect(jsonPath("$.isAdmin").value("true"));
+//    }
+//
+//    @Test
+//    void testCheckAuthStatus_AuthenticatedFaculty() throws Exception {
+//        when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(true);
+//        when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn("test@sandiego.edu");
+//        //when(...get user role...).thenReturn(...faculty...); //TODO method
+//
+//        mockMvc.perform(get("/check-auth"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.isAuthenticated").value("true"))
+//                .andExpect(jsonPath("$.isFaculty").value("true"));
+//    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
@@ -1,0 +1,73 @@
+/**
+ * Tests that the controller for our endpoint to respond with current authentication status returns 
+ * expected responses to the frontend.
+ * 
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.authentication;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthControllerTest {
+
+    private AuthController authController;
+
+    @Mock
+    private OAuthChecker mockOAuthChecker;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        authController = new AuthController(mockOAuthChecker);
+    }
+
+    @Test
+    void testCheckAuthStatus_Unauthenticated() {
+        Map<String, String> defaultResponse = Map.of(
+                "isAuthenticated", "false",
+                "isStudent", "false",
+                "isFaculty", "false",
+                "isAdmin", "false"
+        );
+
+        when(mockOAuthChecker.getDefaultResponse()).thenReturn(defaultResponse);
+        when(mockOAuthChecker.isAuthenticated(any())).thenReturn(false);
+
+        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(defaultResponse, response.getBody());
+    }
+
+    @Test
+    void testCheckAuthStatus_Authenticated() {
+        Map<String, String> expectedResponse = Map.of(
+                "isAuthenticated", "true",
+                "isStudent", "true",
+                "isFaculty", "false",
+                "isAdmin", "false"
+        );
+
+        Authentication mockAuth = mock(Authentication.class);
+        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn("test@student.example.com");
+
+        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+
+        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(expectedResponse.get("isAuthenticated"), response.getBody().get("isAuthenticated"));
+        assertEquals(expectedResponse.get("isStudent"), response.getBody().get("isStudent"));
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/OAuthCheckerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/OAuthCheckerTest.java
@@ -1,0 +1,89 @@
+/**
+ * Tests that the OAuthChecker service methods return expected output.
+ * 
+ * @author Natalie Jungquist 
+ */
+
+package COMP_49X_our_search.backend.authentication;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class OAuthCheckerTest {
+
+    private OAuthChecker OAuthChecker;
+
+    @BeforeEach
+    void setUp() {
+        OAuthChecker = new OAuthChecker();
+    }
+
+    @Test
+    void testGetDefaultResponse() {
+        Map<String, String> expectedResponse = new HashMap<>();
+        expectedResponse.put("isAuthenticated", "false");
+        expectedResponse.put("isStudent", "false");
+        expectedResponse.put("isFaculty", "false");
+        expectedResponse.put("isAdmin", "false");
+
+        Map<String, String> actualResponse = OAuthChecker.getDefaultResponse();
+
+        assertEquals(expectedResponse, actualResponse, "Default response should match expected structure.");
+    }
+
+    @Test
+    void testIsAuthenticated_WithOAuth2AuthenticationToken() {
+        Authentication mockAuth = mock(OAuth2AuthenticationToken.class);
+        assertTrue(OAuthChecker.isAuthenticated(mockAuth), "OAuth2AuthenticationToken should be authenticated.");
+    }
+
+    @Test
+    void testIsAuthenticated_WithNonOAuthAuthentication() {
+        Authentication mockAuth = mock(Authentication.class);
+        assertFalse(OAuthChecker.isAuthenticated(mockAuth), "Non-OAuth authentication should not be authenticated.");
+    }
+
+    @Test
+    void testGetAuthUserEmail_WithValidEmail() {
+        OAuth2User mockUser = mock(OAuth2User.class);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", "test@example.com");
+
+        when(mockUser.getAttributes()).thenReturn(attributes);
+
+        OAuth2AuthenticationToken mockAuth = mock(OAuth2AuthenticationToken.class);
+        when(mockAuth.getPrincipal()).thenReturn(mockUser);
+
+        String email = OAuthChecker.getAuthUserEmail(mockAuth);
+        assertEquals("test@example.com", email, "Email should be extracted correctly.");
+    }
+
+    @Test
+    void testGetAuthUserEmail_WithNoEmailAttribute() {
+        OAuth2User mockUser = mock(OAuth2User.class);
+        when(mockUser.getAttributes()).thenReturn(new HashMap<>());
+
+        OAuth2AuthenticationToken mockAuth = mock(OAuth2AuthenticationToken.class);
+        when(mockAuth.getPrincipal()).thenReturn(mockUser);
+
+        String email = OAuthChecker.getAuthUserEmail(mockAuth);
+        assertEquals("", email, "Should return empty string if no email attribute is present.");
+    }
+
+    @Test
+    void testGetAuthUserEmail_WithNonOAuthAuthentication() {
+        Authentication mockAuth = mock(Authentication.class);
+        String email = OAuthChecker.getAuthUserEmail(mockAuth);
+        assertEquals("", email, "Should return empty string for non-OAuth authentication.");
+    }
+}
+


### PR DESCRIPTION
# Overview

**Type of Change:**
New Feature

**Summary:**
Created an endpoint on the backend to retrieve the current user's authentication status. If the user is authenticated, the backend can respond saying that yes, they are. At this endpoint the backend can also tell the client what the user role is (student, faculty, admin). 

## UI/UX Implementation
None

## Model Updates
None

### Data Models
None

### Object-Oriented Models
New OAuthChecker class. This service checks if a user is authenticated, retrieves the authenticated user's email, provide a default authentication response structure. This class implements an interface I created called AuthCheckerInterface. This is in case we switch to another auth provider.  Note that this is for oauth2 login but we could switch to CAS.

I created the endpoint with a controller, an interface for a service the endpoint can use to handle the single responsibility principle, and the actual implementation.

## End-to-End Testing Instructions
1. start the backend application
2. navigate to backendurl/check-auth
3. view the response in the network response body inspection on your browser
