### PR TITLE
Added users table and get user role functionality

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/User.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/User.java
@@ -1,0 +1,57 @@
+package COMP_49X_our_search.backend.database.entities;
+
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private UserRole userRole;
+
+  public User() {}
+
+  public User(String email, UserRole userRole) {
+    this.email = email;
+    this.userRole = userRole;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public UserRole getUserRole() {
+    return userRole;
+  }
+
+  public void setUserRole(UserRole userRole) {
+    this.userRole = userRole;
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/enums/UserRole.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/enums/UserRole.java
@@ -1,0 +1,6 @@
+package COMP_49X_our_search.backend.database.enums;
+
+public enum UserRole {
+  STUDENT,
+  FACULTY
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/UserRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/UserRepository.java
@@ -1,0 +1,10 @@
+package COMP_49X_our_search.backend.database.repositories;
+
+import COMP_49X_our_search.backend.database.entities.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository
+    extends JpaRepository<User, Integer> {
+  Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
@@ -1,0 +1,24 @@
+package COMP_49X_our_search.backend.database.services;
+
+import COMP_49X_our_search.backend.database.entities.User;
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  @Autowired
+  public UserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public UserRole getUserRoleByEmail(String email) {
+    return userRepository.findByEmail(email)
+        .map(User::getUserRole)
+        .orElseThrow(() -> new RuntimeException("User not found"));
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/UserServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/UserServiceTest.java
@@ -1,0 +1,60 @@
+package COMP_49X_our_search.backend.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import COMP_49X_our_search.backend.database.entities.User;
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.repositories.UserRepository;
+import COMP_49X_our_search.backend.database.services.UserService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class UserServiceTest {
+
+  @Autowired
+  private UserService userService;
+
+  @MockBean
+  private UserRepository userRepository;
+
+  private User user;
+
+  @BeforeEach
+  void setUp() {
+    user = new User();
+    user.setEmail("test@test.com");
+    user.setUserRole(UserRole.STUDENT);
+  }
+
+  @Test
+  void testGetUserRoleByEmail_invalidEmail_throwsException() {
+    when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(user));
+
+    UserRole userRole = userService.getUserRoleByEmail("test@test.com");
+
+    assertEquals(UserRole.STUDENT, userRole);
+  }
+
+  @Test
+  void testGetUserRoleByEmail_validEmail_returnsExpectedResult() {
+    when(userRepository.findByEmail("invalid@invalid.com")).thenReturn(Optional.empty());
+
+    RuntimeException exception = assertThrows(RuntimeException.class, () ->
+        userService.getUserRoleByEmail("invalid@invalid.com")
+    );
+
+    assertEquals("User not found", exception.getMessage());
+    verify(userRepository, times(1)).findByEmail("invalid@invalid.com");
+  }
+}


### PR DESCRIPTION
# Overview

**Type of Change:** New feature

**Summary:** Added User Hibernate Entity. Added UserService with get user by role functionality

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

Added "users" table that contains keys: `id` (primary), `email` (unique), and `userRole`.

### Object-Oriented Models

Added new JpaRepository called UserRepository with `findByEmail()` method. Added new UserService with `getUserRoleByEmail()` method.

## End-to-End Testing Instructions

1) Make sure that the database has at least one user with set email and userRole in the "users" table.
2) Call the `getUserRoleByEmail()` method providing the existing email, and verify that the returned user role matches the expected result. Alternatively, call the method with a non-existent email and make sure that the method throws an exception with message "User not found".
