### PR TITLE
Google oauth2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,6 @@ jobs:
 
     - name: Create secrets.properties file using Github secrets
       run: |
-        ls
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> src/main/resources/secrets.properties
         echo "spring.security.oauth2.client.registration.google.client_id=${{ secrets.DEVMODE_GOOGLE_CLIENT_ID }}" >> src/main/resources/secrets.properties
         echo "spring.security.oauth2.client.registration.google.client_secret=${{ secrets.DEVMODE_GOOGLE_CLIENT_SECRET }}" >> src/main/resources/secrets.properties

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,6 +36,12 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+    - name: Create secrets.properties file using Github secrets
+      run: |
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/src/main/resources/secrets.properties
+        echo "spring.security.oauth2.client.registration.google.client_id=${{ secrets.DEVMODE_GOOGLE_CLIENT_ID }}" >> backend/src/main/resources/secrets.properties
+        echo "spring.security.oauth2.client.registration.google.client_secret=${{ secrets.DEVMODE_GOOGLE_CLIENT_SECRET }}" >> backend/src/main/resources/secrets.properties
+
     - name: Build with Gradle Wrapper
       # NOTE: Running './gradlew build' will, by default, run all unit tests as part of the process.
       run: ./gradlew build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,9 +38,10 @@ jobs:
 
     - name: Create secrets.properties file using Github secrets
       run: |
-        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/src/main/resources/secrets.properties
-        echo "spring.security.oauth2.client.registration.google.client_id=${{ secrets.DEVMODE_GOOGLE_CLIENT_ID }}" >> backend/src/main/resources/secrets.properties
-        echo "spring.security.oauth2.client.registration.google.client_secret=${{ secrets.DEVMODE_GOOGLE_CLIENT_SECRET }}" >> backend/src/main/resources/secrets.properties
+        ls
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> src/main/resources/secrets.properties
+        echo "spring.security.oauth2.client.registration.google.client_id=${{ secrets.DEVMODE_GOOGLE_CLIENT_ID }}" >> src/main/resources/secrets.properties
+        echo "spring.security.oauth2.client.registration.google.client_secret=${{ secrets.DEVMODE_GOOGLE_CLIENT_SECRET }}" >> src/main/resources/secrets.properties
 
     - name: Build with Gradle Wrapper
       # NOTE: Running './gradlew build' will, by default, run all unit tests as part of the process.

--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
@@ -6,18 +6,14 @@
  * @author Natalie Jungquist
  */
 
-// TODO : NOTE THIS IS CURRENTLY A CLASS STUB. ITS TESTS AND FUNCTIONS HAVE NOT BEEN IMPLEMENTED
-
 package COMP_49X_our_search.backend.authentication;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.security.PublicKey;
 import java.util.Map;
 
 @RestController

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/EmailValidator.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/EmailValidator.java
@@ -1,0 +1,11 @@
+package COMP_49X_our_search.backend.security;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmailValidator {
+
+    boolean isValidEmail(String email, String ALLOWED_DOMAIN) {
+        return ALLOWED_DOMAIN != null && email != null && email.endsWith(ALLOWED_DOMAIN);
+    }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/OAuthSuccessHandler.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/OAuthSuccessHandler.java
@@ -1,0 +1,76 @@
+/**
+ * This class handles the redirection after a successful login.
+ * It extends Spring's `SavedRequestAwareAuthenticationSuccessHandler` and overrides Spring's onAuthenticationSuccess
+ * to ensure that after successful authentication, the user is redirected to a URL on the frontend.
+ * SecurityConfig registers this class to configure it to the application.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuthSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+    private static final String frontendUrl = "http://localhost:3000"; // TODO hardcoded for now
+    private static final String ALLOWED_DOMAIN = "@sandiego.edu";
+    private static final String invalidEmailPath = "/invalid-email";
+
+    private final EmailValidator emailValidator;
+
+    public OAuthSuccessHandler(EmailValidator emailValidator) {
+        this.emailValidator = emailValidator;
+    }
+
+    /**
+     * Handles a successful authentication event by storing the user role
+     * and redirecting the user to the authenticated page of the frontend app.
+     *
+     * @param request the HttpServletRequest object that contains the request the client made to the servlet
+     * @param response the HttpServletResponse object that contains the response the servlet returns to the client
+     * @param authentication the Authentication object that represents the successful authentication
+     * @throws ServletException if a servlet-specific error occurs * @throws IOException if an I/O error occurs
+     * */
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws ServletException, IOException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String email = oAuth2User.getAttribute("email");
+
+        if (!emailValidator.isValidEmail(email, ALLOWED_DOMAIN)) {
+            rejectAuthentication(request, response);
+            return;
+        }
+
+        this.setAlwaysUseDefaultTargetUrl(true);
+        this.setDefaultTargetUrl(frontendUrl);
+        super.onAuthenticationSuccess(request, response, authentication);
+    }
+
+    private void rejectAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        System.out.println("login: unauthorized email domain -> sending error");
+
+        // Log the user out & clear all cookies
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        SecurityContextLogoutHandler logoutHandler = new SecurityContextLogoutHandler();
+        logoutHandler.logout(request, response, authentication);
+        SecurityContextHolder.clearContext(); // clears the Authentication information saved by Spring Security's SecurityContextHolder
+        request.getSession().invalidate();
+        new CookieClearingLogoutHandler(AbstractRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY).logout(request, response, authentication);
+
+        response.sendRedirect(frontendUrl + invalidEmailPath);
+    }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/SecurityConfig.java
@@ -1,0 +1,92 @@
+/**
+ *  This configuration class defines security settings for the application using Spring Security.
+ *  The SecurityFilterChain is provided by Spring Security: https://docs.spring.io/spring-security/reference/servlet/configuration/java.html
+ *  Disables CSRF protection as OAuth2 login may rely on browser redirects that can be interrupted by CSRF protection.
+ *  Configures CORS to allow requests only from the specified frontend URL.
+ *  Defines security rules for different URLs, ensuring public access to `/check-auth` while requiring authentication for all others.
+ *  Setts up OAuth2 login and specifying the `LoginSuccessHandler` for redirection upon successful login.
+ *  Configures logout behavior and clearing session data and cookies.
+ *
+ *  @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private static final String frontendUrl = "http://localhost:3000";
+
+    private final OAuthSuccessHandler oAuthSuccessHandler;
+
+    public SecurityConfig(OAuthSuccessHandler oAuthSuccessHandler) {
+        this.oAuthSuccessHandler = oAuthSuccessHandler;
+    }
+
+    /**
+     * Configures various aspects of the security filter chain for an application,
+     * including CSRF protection, CORS configuration, request authorization, OAuth2 login, and logout actions.
+     *
+     * @param http the HttpSecurity object to configure
+     * @return the configured SecurityFilterChain object
+     * @throws Exception if an error occurs while configuring the HttpSecurity object
+     */
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable) // Disable cross-site request forgery because OAuth2 login flows can be interrupted by CSRF protection since the login process relies on browser redirects
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers("/check-auth").permitAll()  // Allow public access to check authorization status
+                                .anyRequest().authenticated() // All other requests require authentication
+                )
+                .oauth2Login(oauth2 ->
+                        oauth2
+                                .successHandler(oAuthSuccessHandler)  // Registers a custom success handler that will make sure a successful login redirects to the frontend
+                )
+                .logout(logout ->
+                        logout
+                                .logoutUrl("/logout") // Backend logout endpoint
+                                .invalidateHttpSession(true)
+                                .clearAuthentication(true)
+                                .deleteCookies("JSESSIONID") // Clear cookie that stores authentication status
+                );
+        return http.build();
+    }
+
+    /**
+     * Sets up the CORS configuration to allow requests only from the specified frontend URL.
+     * It permits all headers, supports various HTTP methods, and allows credentials to be included in requests.
+     *
+     * @return the configured CorsConfigurationSource object
+     */
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        // Configures this server so it can only receive requests coming from the frontendUrl.
+        // This only affects cross-origin requests made via JavaScript.
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(frontendUrl));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,9 +1,24 @@
 spring.application.name=backend
 
+# Base URLs
+backend-url=http://localhost:8080
+frontend-url=http://localhost:3000
+
+# Backend endpoints
+oauth-redirect-endpoint=/login/oauth2/code/google
+# login=/oauth2/authorization/google
+
+# Frontend paths
+hasProfilePath=/posts
+noProfilePath=/ask-for-role
+
+# Secrets file stores sensitive information
+spring.config.import=optional:secrets.properties
+
 # MySQL Configuration
 spring.datasource.url=jdbc:mysql://localhost:3306/forum
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Hibernate Configuration

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -46,12 +48,13 @@ class AuthControllerTest {
 
         ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
-        assertEquals(200, response.getStatusCodeValue());
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
         assertEquals(defaultResponse, response.getBody());
     }
 
+    @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
     @Test
-    void testCheckAuthStatus_Authenticated() {
+    void testCheckAuthStatus_AuthenticatedStudent() {
         Map<String, String> expectedResponse = Map.of(
                 "isAuthenticated", "true",
                 "isStudent", "true",
@@ -66,8 +69,54 @@ class AuthControllerTest {
 
         ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
-        assertEquals(200, response.getStatusCodeValue());
-        assertEquals(expectedResponse.get("isAuthenticated"), response.getBody().get("isAuthenticated"));
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
         assertEquals(expectedResponse.get("isStudent"), response.getBody().get("isStudent"));
+    }
+
+    @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
+    @Test
+    void testCheckAuthStatus_AuthenticatedFaculty() {
+        Map<String, String> expectedResponse = Map.of(
+                "isAuthenticated", "true",
+                "isStudent", "false",
+                "isFaculty", "true",
+                "isAdmin", "false"
+        );
+
+        // TODO once method to get user role from DB is implemented
+//        Authentication mockAuth = mock(Authentication.class);
+//        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+//        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+//        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn("test@faculty.example.com");
+//
+//        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+//
+//        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+//        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+//        assertEquals(expectedResponse.get("isFaculty"), response.getBody().get("isFaculty"));
+    }
+
+    @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
+    @Test
+    void testCheckAuthStatus_AuthenticatedAdmin() {
+        Map<String, String> expectedResponse = Map.of(
+                "isAuthenticated", "true",
+                "isStudent", "false",
+                "isFaculty", "false",
+                "isAdmin", "true"
+        );
+
+        // TODO once method to get user role from DB is implemented
+//        Authentication mockAuth = mock(Authentication.class);
+//        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+//        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+//        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn("test@admin.example.com");
+//
+//        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+//
+//        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+//        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+//        assertEquals(expectedResponse.get("isAdmin"), response.getBody().get("isAdmin"));
     }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -8,8 +8,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import proto.core.Core.ModuleConfig;
 import proto.core.Core.ModuleResponse;
@@ -22,7 +25,9 @@ import proto.fetcher.DataTypes.MajorWithProjects;
 import proto.fetcher.DataTypes.ProjectHierarchy;
 import proto.fetcher.FetcherModule.FetcherResponse;
 
-@WebMvcTest(GatewayController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class GatewayControllerTest {
 
     @Autowired
@@ -70,6 +75,7 @@ public class GatewayControllerTest {
     }
 
     @Test
+    @WithMockUser // include this annotation to mock that a user is authenticated to access the protected endpoints of the application
     void getProjects_returnsExpectedResult() throws Exception {
         when(moduleInvoker.processConfig(
                 org.mockito.ArgumentMatchers.any(ModuleConfig.class)))

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/EmailValidatorTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/EmailValidatorTest.java
@@ -1,0 +1,39 @@
+/**
+ * Tests for the email validator. Checks that the email validation method return true or false correctly.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EmailValidatorTest {
+
+    private static final String ALLOWED_DOMAIN = "@sandiego.edu";
+    private EmailValidator emailValidator;
+
+    @BeforeEach
+    public void setUp() {
+        emailValidator = new EmailValidator();
+    }
+
+    @Test
+    void testHandlesValidEmail() {
+        String valid = "test@sandiego.edu";
+        assertTrue(emailValidator.isValidEmail(valid, ALLOWED_DOMAIN));
+    }
+    @Test
+    void testHandlesInValidEmail() {
+        String invalid = "test@invalid.com";
+        assertFalse(emailValidator.isValidEmail(invalid, ALLOWED_DOMAIN));
+    }
+    @Test
+    void testHandlesNulls() {
+        assertFalse(emailValidator.isValidEmail(null, ALLOWED_DOMAIN));
+        assertFalse(emailValidator.isValidEmail("test@sandiego.edu", null));
+        assertFalse(emailValidator.isValidEmail("test@invalid.com", null));
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessHandlerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessHandlerTest.java
@@ -1,0 +1,81 @@
+/**
+ * The LoginSuccessHandler class overrides Spring Security's onAuthenticationSuccess() method.
+ * These tests ensure that the class correctly handles authentication success scenarios.
+ * If the login should succeed, the only verification we can do at the unit level is
+ * ensuring that no exceptions are thrown.
+ * If the login should not succeed, we test that login does not complete and an error occurs.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+public class OAuthSuccessHandlerTest {
+
+    private static final String frontendUrl = "http://localhost:3000";
+    private static final String invalidEmailPath = "/invalid-email";
+
+    private OAuthSuccessHandler OAuthSuccessHandler;
+
+    @Mock
+    private EmailValidator emailValidator;  // Mock EmailValidator
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private OAuth2User oAuth2User;
+    @Mock
+    private HttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        OAuthSuccessHandler = new OAuthSuccessHandler(emailValidator);
+
+        when(authentication.getPrincipal()).thenReturn(oAuth2User);
+        when(request.getSession()).thenReturn(session);
+    }
+
+    @Test
+    void testGivenValidAuth_oauthSuccess_RedirectsToFrontend() throws ServletException, IOException {
+        when(oAuth2User.getAttribute("email")).thenReturn("test@sandiego.edu");
+        when(emailValidator.isValidEmail("test@sandiego.edu", "@sandiego.edu")).thenReturn(true);
+
+        OAuthSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+        verify(response, never()).sendError(anyInt(), anyString()); // No errors for a valid email
+    }
+
+    @Test
+    void testGivenInvalidAuth_loginFails() throws ServletException, IOException {
+        when(oAuth2User.getAttribute("email")).thenReturn("test@invalid-domain.com");
+        when(emailValidator.isValidEmail("test@invalid-domain.com", "@sandiego.edu")).thenReturn(false);
+
+        OAuthSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+
+        verify(session).invalidate(); //Session ends to ensure the user does not get logged in
+        verify(response).sendRedirect(frontendUrl + invalidEmailPath);
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessIntegrationTest.java
@@ -1,0 +1,50 @@
+/**
+ * This class contains integration tests for the login success scenario. These tests verify that the user is correctly redirected
+ * after a successful OAuth2 login. The OAuth2 login process is mocked to simulate a successful authentication.
+ *
+ * @SpringBootTest This annotation loads the application context and enable full integration tests so all components
+ * and beans are available for testing. Used to make sure that the custom security setup is in place and test the web layer.
+ * @ActiveProfiles("test") This annotation specifies the active profile as "test", ensuring that the test-specific configuration
+ * is loaded and applied. Used because this test does not need to load in the real database.
+ * @AutoConfigureMockMvc This annotation autoconfigures MockMvc, a tool that sets up the necessary components to simulate
+ * the web layer (HTTP requests and responses) without the need for a running server.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+public class OAuthSuccessIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testOAuth2LoginSuccessRedirect() throws Exception {
+        // This test simulates a successful OAuth2 login and verifies that after authentication,
+        // the user is redirected to the expected frontend URL. Since Spring Security handles
+        // the actual OAuth2 callback, we use oauth2Login() to mock a successful authentication.
+        mockMvc.perform(get("/login/oauth2/code/google")
+                        .param("state", "some-state")
+                        .param("code", "some-auth-code")
+                        .param("scope", "email profile openid")
+                        .with(oauth2Login()))
+                .andExpect(status().is3xxRedirection());
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityConfigTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityConfigTest.java
@@ -1,0 +1,64 @@
+/**
+ * This class contains unit tests for the SecurityConfig class. These tests ensure that the SecurityConfig class
+ * sets up the expected security configurations, contributing to the overall security and integrity of the application.
+ * *
+ * These tests do not go in depth on the SecurityFilterChain bean because Spring Security handles the complex details
+ * of building the chain. Instead, these tests focus on verifying that the SecurityConfig provides the correct
+ * configuration to HttpSecurity. The outcomes of the security rules are tested with integration tests.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityConfigTest {
+
+    @Mock
+    private OAuthSuccessHandler oAuthSuccessHandler;
+
+    private static final String frontendUrl = "http://localhost:3000";
+
+    @Test
+    void testSecurityConfig_CorsConfigNotNull() throws Exception {
+        SecurityConfig securityConfig = new SecurityConfig(oAuthSuccessHandler);
+
+        CorsConfigurationSource corsConfigurationSource = securityConfig.corsConfigurationSource();
+        assertThat(corsConfigurationSource).isNotNull();
+    }
+
+    @Test
+    void testCorsConfig_IsUrlBased() throws Exception {
+        SecurityConfig securityConfig = new SecurityConfig(oAuthSuccessHandler);
+        CorsConfigurationSource corsConfigurationSource = securityConfig.corsConfigurationSource();
+
+        assertThat(corsConfigurationSource).isInstanceOf(UrlBasedCorsConfigurationSource.class);
+    }
+
+    @Test
+    void testCorsConfig_OnlyAllowsFrontendRequests() throws Exception {
+        SecurityConfig securityConfig = new SecurityConfig(oAuthSuccessHandler);
+        CorsConfigurationSource corsConfigurationSource = securityConfig.corsConfigurationSource();
+
+        UrlBasedCorsConfigurationSource urlSource = (UrlBasedCorsConfigurationSource) corsConfigurationSource;
+        Map<String, CorsConfiguration> allConfigs = urlSource.getCorsConfigurations();
+
+        assertThat(allConfigs).containsKey("/**");
+        Map.Entry<String, CorsConfiguration> registeredConfig = allConfigs.entrySet().iterator().next();
+        CorsConfiguration config = registeredConfig.getValue();
+
+        assertThat(config.getAllowedOrigins()).contains(frontendUrl);
+        assertThat(config.getAllowedMethods()).contains("GET", "POST", "PUT", "DELETE", "OPTIONS");
+        assertThat(config.getAllowCredentials()).isTrue();
+        assertThat(config.getAllowedHeaders()).contains("*");
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityIntegrationTest.java
@@ -9,6 +9,8 @@
  * is loaded and applied. Used because this test does not need to load in the real database.
  * @AutoConfigureMockMvc This annotation autoconfigures MockMvc, a tool that sets up the necessary components to simulate
  * the web layer (HTTP requests and responses) without the need for a running server.
+ * @WithMockUser This annotation simulates the client being authenticated to access a backend resource. Exclusion of this annotation
+ * simulates a client that is not authenticated trying to access an endpoint.
  *
  * @author Natalie Jungquist
  */

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityIntegrationTest.java
@@ -1,0 +1,94 @@
+/**
+ * This class contains integration tests for the security configuration.
+ * These tests verify various security-related functionalities, including public and protected endpoint access,
+ * OAuth2 login redirection, CORS configuration, and session invalidation upon logout.
+ *
+ * @SpringBootTest This annotation loads the application context and enable full integration tests so all components
+ * and beans are available for testing. Used to make sure that the custom security setup is in place and test the web layer.
+ * @ActiveProfiles("test") This annotation specifies the active profile as "test", ensuring that the test-specific configuration
+ * is loaded and applied. Used because this test does not need to load in the real database.
+ * @AutoConfigureMockMvc This annotation autoconfigures MockMvc, a tool that sets up the necessary components to simulate
+ * the web layer (HTTP requests and responses) without the need for a running server.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class SecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testGivenNoAuth_whenAccessCheckAuth_thenOk() throws Exception {
+        // The endpoint to verify the user's application status is public.
+        // Test to ensure CSRF protection is disabled:
+        // Verify that the CSRF protection doesn't block a request to a public endpoint.
+        mockMvc.perform(get("/check-auth"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testGivenNoAuth_whenLogin_redirectsToOAuthProvider() throws Exception {
+        mockMvc.perform(get("/oauth2/authorization/google"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("https://accounts.google.com/o/oauth2/**"));
+    }
+
+    @Test
+    void testGivenNoAuth_whenAccessProtectedEndpoint_thenRedirectToLogin() throws Exception {
+        //  When an unauthenticated request is made to a protected URL,
+        //  Spring Security invokes its authentication entry point—which, by default,
+        //  redirects the client (302) to the login page.
+        mockMvc.perform(get("/projects"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/oauth2/authorization/google"));
+    }
+
+    @Test
+    @WithMockUser // This annotation makes mocks the user being authenticated
+    void testGivenUserAuth_whenAccessProtectedEndpoint_thenOk() throws Exception {
+        // When an authenticated request is made to a protected URL,
+        // the requested resource is available.
+        mockMvc.perform(get("/projects"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testAcceptFrontendOrigin() throws Exception {
+        mockMvc.perform(get("/check-auth")
+                        .header("Origin", "http://localhost:3000"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testRejectInvalidOrigins() throws Exception {
+        mockMvc.perform(get("/check-auth")
+                        .header("Origin", "https://invalid-origin.com"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser
+    void testLogoutInvalidatesSession() throws Exception {
+        mockMvc.perform(post("/logout"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/login?logout"));
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,4 +1,5 @@
-spring.datasource.url=jdbc:h2:mem:testdb
+# H2 In-Memory Database Configuration for Tests
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;IGNORECASE=TRUE;DATABASE_TO_UPPER=FALSE  
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password

--- a/frontend/src/__tests__/MainLayout.test.js
+++ b/frontend/src/__tests__/MainLayout.test.js
@@ -8,23 +8,17 @@ describe('MainLayout', () => {
   test('calls fetchPostings when it renders', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps) // Mocking the function to resolve with an empty array
 
-    render(<MainLayout
-      isStudent
-      fetchPostings={mockFetchPostings}
-           />)
+    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings}/>)
 
     await waitFor(() => {
-      expect(mockFetchPostings).toHaveBeenCalledWith(true) // Verify the mock function was called with correct argument
+      expect(mockFetchPostings).toHaveBeenCalledWith(true, false, false) // Verify the mock function was called with correct argument
     })
   })
 
   test('renders app title', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps)
 
-    render(<MainLayout
-      isStudent
-      fetchPostings={mockFetchPostings}
-           />)
+    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings}/>)
 
     await waitFor(() => {
       const title = screen.getByRole('button', { name: appTitle })

--- a/frontend/src/__tests__/MainLayout.test.js
+++ b/frontend/src/__tests__/MainLayout.test.js
@@ -8,7 +8,7 @@ describe('MainLayout', () => {
   test('calls fetchPostings when it renders', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps) // Mocking the function to resolve with an empty array
 
-    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings}/>)
+    render(<MainLayout isStudent isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
 
     await waitFor(() => {
       expect(mockFetchPostings).toHaveBeenCalledWith(true, false, false) // Verify the mock function was called with correct argument
@@ -18,7 +18,7 @@ describe('MainLayout', () => {
   test('renders app title', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps)
 
-    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings}/>)
+    render(<MainLayout isStudent isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
 
     await waitFor(() => {
       const title = screen.getByRole('button', { name: appTitle })

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -14,17 +14,17 @@ import ViewProfile from './ViewProfile'
 import Sidebar from './Sidebar'
 import PropTypes from 'prop-types'
 
-function MainLayout ({ isStudent, fetchPostings }) {
+function MainLayout ({ fetchPostings, isStudent, isFaculty, isAdmin }) {
   const [selectedPost, setSelectedPost] = useState(null)
   const [postings, setPostings] = useState([])
 
   useEffect(() => {
     const fetchData = async () => {
-      const posts = await fetchPostings(isStudent)
+      const posts = await fetchPostings(isStudent, isFaculty, isAdmin)
       setPostings(posts)
     }
     fetchData()
-  }, [fetchPostings, isStudent])
+  }, [fetchPostings, isStudent, isFaculty, isAdmin])
 
   return (
     <Box sx={{

--- a/frontend/src/utils/fetchPostings.js
+++ b/frontend/src/utils/fetchPostings.js
@@ -5,7 +5,7 @@
  *  - all of the data for the departments
  *  - the majors under each department
  *  - and the postings under each major
- * 
+ *
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */
 

--- a/frontend/src/utils/fetchPostings.js
+++ b/frontend/src/utils/fetchPostings.js
@@ -1,22 +1,26 @@
+/**
+ * @file Function that filters for the postings to be displayed to the user.
+ * The postings will either be students (if isFaculty) or research opportunities (if isStudent).
+ * Returns:
+ *  - all of the data for the departments
+ *  - the majors under each department
+ *  - and the postings under each major
+ * 
+ * @author Natalie Jungquist <njungquist@sandiego.edu>
+ */
+
 import { fetchStudentsUrl, fetchProjectsUrl } from '../resources/constants'
+import PropTypes from 'prop-types'
 
-const fetchPostings = async (isStudent) => {
-  // Params:
-  // isStudent: true if the user is a student
-  // Filters for the postings
-
-  // Returns:
-  // all of the data for the departments
-  // the majors under each department
-  // and the postings under each major
-  // The postings will either be students (if isFaculty) or research opportunities (if isStudent)
-
+const fetchPostings = async (isStudent, isFaculty, isAdmin) => {
   let endpointUrl = ''
 
   if (isStudent) {
     endpointUrl = fetchProjectsUrl
-  } else if (!isStudent) {
+  } else if (isFaculty) {
     endpointUrl = fetchStudentsUrl
+  } else {
+    return []
   }
 
   try {
@@ -24,7 +28,8 @@ const fetchPostings = async (isStudent) => {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
-      }
+      },
+      credentials: 'include'
     })
     if (!response.ok) {
       throw new Error('Failed to fetch postings')
@@ -37,6 +42,11 @@ const fetchPostings = async (isStudent) => {
 
   // Return an empty list if the fetch call fails
   return []
+}
+
+fetchPostings.propTypes = {
+  isStudent: PropTypes.bool.isRequired,
+  isFaculty: PropTypes.bool.isRequired
 }
 
 export default fetchPostings


### PR DESCRIPTION
# Overview

**Type of Change:**  New Feature

**Summary:** 
Implemented Google OAuth2 security for the backend application. Now all backend endpoints like /projects are not accessible unless you have logged in with Google and a USD email address. The backend is protected from anyone accessing the OUR's information now. 

## UI/UX Implementation
No changes

### Data Models
No changes

### Object-Oriented Models
- SecurityConfig is a class that extends one of Java Spring Security's classes to create a securityFilterChain which tells the backend what parts of the app to secure and how to secure them. 
- EmailValidator checks if the user's email is valid. 
- OAuthSuccessHandler overrides one of Java Spring Security's classes to handle what to do once the user has tried to log in with the oauth provider, in our case Google. 

## End-to-End Testing Instructions
1. navigating to http://localhost:8080 will prompt you to login with google and ask for OUR SEARCH app authentication
2. navigating to http://localhost:8080/projects will not let you see the projects unless you have logged in with google already. If not logged in already, you will be sent back to google's login screen.
3. try to log in with a USD email, you will go to the http://localhost:3000
4. try to log in with a non-USD email, you will be sent to http://localhost:3000/invalid-email and you cannot access http://localhost:8080/projects (/invalid-email route on the frontend is not yet implemented, so you will see 404 for now)
5. you can navigate to http://localhost:8080/check-auth regardless of if you have logged in already or not