### PR TITLE
Check if user role is Professor and render the correct postings

### DIFF
--- a/frontend/src/__tests__/MainAccordion.test.js
+++ b/frontend/src/__tests__/MainAccordion.test.js
@@ -1,51 +1,151 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import MajorAccordion from '../components/MajorAccordion'
-import { mockMajorNoPosts, mockMajorOnePost } from '../resources/mockData'
+import MainAccordion from '../components/MainAccordion'
+import { errorLoadingPostingsMessage, noPostsMessage } from '../resources/constants'
 
-describe('MajorAccordion', () => {
-  const mockSetSelectedPost = jest.fn()
-
-  test('renders major name', () => {
+describe('MainAccordion', () => {
+  test('renders error message when no postings are provided', () => {
     render(
-      <MajorAccordion
-        major={mockMajorNoPosts}
-        numPosts={mockMajorNoPosts.posts.length}
-        setSelectedPost={mockSetSelectedPost}
-        isStudent
+      <MainAccordion
+        postings={[]}
+        setSelectedPost={() => {}}
+        isStudent={true}
+        isFaculty={false}
+        isAdmin={false}
       />
     )
-
-    // Find the major name using test ID instead of text content
-    // to account for multiple elements that include the name of the
-    // major.
-    const majorNameEl = screen.getByTestId('major-name')
-    expect(majorNameEl).toHaveTextContent(mockMajorNoPosts.name)
-    expect(screen.getByText('(0 opportunities)')).toBeInTheDocument()
+    expect(screen.getByText(errorLoadingPostingsMessage)).toBeInTheDocument()
   })
 
-  test('renders posts for the major', async () => {
+  test('renders discipline accordions when postings exist (student view)', () => {
+    const mockPostings = [
+      {
+        id: 1,
+        name: 'Discipline One',
+        majors: [
+          {
+            id: 10,
+            name: 'Major A',
+            posts: [] // No posts in Major A
+          },
+          {
+            id: 11,
+            name: 'Major B',
+            posts: [
+              {
+                id: 101,
+                name: 'Post 1',
+                isActive: true,
+                faculty: { firstName: 'John', lastName: 'Doe' },
+                researchPeriods: ['Fall']
+              }
+            ]
+          }
+        ]
+      },
+      {
+        id: 2,
+        name: 'Discipline Two',
+        majors: [] // No majors for Discipline Two
+      }
+    ]
+
     render(
-      <MajorAccordion
-        major={mockMajorOnePost}
-        numPosts={mockMajorOnePost.posts.length}
-        setSelectedPost={mockSetSelectedPost}
-        isStudent
+      <MainAccordion
+        postings={mockPostings}
+        setSelectedPost={() => {}}
+        isStudent={true}
+        isFaculty={false}
+        isAdmin={false}
       />
     )
+    // Verify that discipline names are rendered.
+    expect(screen.getByText('Discipline One')).toBeInTheDocument()
+    expect(screen.getByText('Discipline Two')).toBeInTheDocument()
 
-    // Find the major name using test ID
-    const majorNameEl = screen.getByTestId('major-name')
-    expect(majorNameEl).toHaveTextContent(mockMajorOnePost.name)
-    expect(screen.getByText('(1 opportunities)')).toBeInTheDocument()
+    // For Discipline Two, since no majors exist, the noPostsMessage should appear.
+    expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
+  })
 
-    // Find and click the accordion summary
-    const accordionButton = screen.getByRole('button')
-    await userEvent.click(accordionButton)
+  test('renders majors for a discipline when they exist (student view)', () => {
+    const mockPostings = [
+      {
+        id: 1,
+        name: 'Discipline One',
+        majors: [
+          {
+            id: 10,
+            name: 'Major A',
+            posts: [
+              {
+                id: 101,
+                name: 'Post 1',
+                isActive: true,
+                faculty: { firstName: 'Jane', lastName: 'Smith' },
+                researchPeriods: ['Spring']
+              }
+            ]
+          }
+        ]
+      }
+    ]
 
-    // After expansion, verify the post content
-    const firstPostName = mockMajorOnePost.posts[0].name
-    expect(screen.getByText(firstPostName)).toBeInTheDocument()
+    render(
+      <MainAccordion
+        postings={mockPostings}
+        setSelectedPost={() => {}}
+        isStudent={true}
+        isFaculty={false}
+        isAdmin={false}
+      />
+    )
+    // Verify that the major name is rendered (via MajorAccordion).
+    expect(screen.getByText('Major A')).toBeInTheDocument()
+  })
+
+  test('renders discipline accordions and faculty post details when in faculty view', () => {
+    const mockPostings = [
+      {
+        id: 1,
+        name: 'Discipline One',
+        majors: [
+          {
+            id: 10,
+            name: 'Major A',
+            posts: [
+              {
+                id: 201,
+                // For faculty view, the PostList renders the faculty details instead of the post name.
+                firstName: 'Alice',
+                lastName: 'Wonder',
+                classStatus: 'Senior',
+                graduationYear: 2025,
+                email: 'alice@example.com',
+                majors: ['Sociology'],
+                isActive: true
+              }
+            ]
+          }
+        ]
+      }
+    ]
+    render(
+      <MainAccordion
+        postings={mockPostings}
+        setSelectedPost={() => {}}
+        isStudent={false}
+        isFaculty={true}
+        isAdmin={false}
+      />
+    )
+    // Verify discipline and major names.
+    expect(screen.getByText('Discipline One')).toBeInTheDocument()
+    expect(screen.getByText('Major A')).toBeInTheDocument()
+    // In faculty view, the PostList should render the faculty details.
+    expect(screen.getByText('Alice Wonder')).toBeInTheDocument()
+    expect(screen.getByText(/Class Status: Senior/)).toBeInTheDocument()
+    expect(screen.getByText(/Graduation Year: 2025/)).toBeInTheDocument()
+    expect(screen.getByText(/Email: alice@example.com/)).toBeInTheDocument()
+    expect(screen.getByText(/Majors: Sociology/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/MainAccordion.test.js
+++ b/frontend/src/__tests__/MainAccordion.test.js
@@ -9,7 +9,7 @@ describe('MainAccordion', () => {
       <MainAccordion
         postings={[]}
         setSelectedPost={() => {}}
-        isStudent={true}
+        isStudent
         isFaculty={false}
         isAdmin={false}
       />
@@ -54,7 +54,7 @@ describe('MainAccordion', () => {
       <MainAccordion
         postings={mockPostings}
         setSelectedPost={() => {}}
-        isStudent={true}
+        isStudent
         isFaculty={false}
         isAdmin={false}
       />
@@ -94,7 +94,7 @@ describe('MainAccordion', () => {
       <MainAccordion
         postings={mockPostings}
         setSelectedPost={() => {}}
-        isStudent={true}
+        isStudent
         isFaculty={false}
         isAdmin={false}
       />
@@ -134,7 +134,7 @@ describe('MainAccordion', () => {
         postings={mockPostings}
         setSelectedPost={() => {}}
         isStudent={false}
-        isFaculty={true}
+        isFaculty
         isAdmin={false}
       />
     )

--- a/frontend/src/__tests__/MainLayout.test.js
+++ b/frontend/src/__tests__/MainLayout.test.js
@@ -4,21 +4,26 @@ import MainLayout from '../components/MainLayout'
 import { mockResearchOps } from '../resources/mockData'
 import { appTitle } from '../resources/constants'
 
+// Mock MainAccordion to capture its props for testing
+jest.mock('../components/MainAccordion', () => (props) => {
+  return <div data-testid="main-accordion">{JSON.stringify(props)}</div>
+})
+
 describe('MainLayout', () => {
   test('calls fetchPostings when it renders', async () => {
-    const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps) // Mocking the function to resolve with an empty array
+    const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps) // Mocking the function to resolve with an array
 
-    render(<MainLayout isStudent isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
+    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
 
     await waitFor(() => {
-      expect(mockFetchPostings).toHaveBeenCalledWith(true, false, false) // Verify the mock function was called with correct argument
+      expect(mockFetchPostings).toHaveBeenCalledWith(true, false, false) // Verify the mock function was called with the correct arguments
     })
   })
 
   test('renders app title', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps)
 
-    render(<MainLayout isStudent isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
+    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
 
     await waitFor(() => {
       const title = screen.getByRole('button', { name: appTitle })
@@ -36,5 +41,21 @@ describe('MainLayout', () => {
 
   test('renders sidebar', () => {
     // Todo in later sprints
+  })
+
+  // New test: verifies that MainAccordion receives the correct props from MainLayout
+  test('passes correct props to MainAccordion', async () => {
+    const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps)
+    render(<MainLayout isStudent={true} isFaculty={true} isAdmin={false} fetchPostings={mockFetchPostings} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('main-accordion')).toBeInTheDocument()
+    })
+
+    const accordionProps = JSON.parse(screen.getByTestId('main-accordion').textContent)
+    expect(accordionProps.isStudent).toBe(true)
+    expect(accordionProps.isFaculty).toBe(true)
+    expect(accordionProps.isAdmin).toBe(false)
+    expect(accordionProps.postings).toEqual(mockResearchOps)
   })
 })

--- a/frontend/src/__tests__/MainLayout.test.js
+++ b/frontend/src/__tests__/MainLayout.test.js
@@ -6,14 +6,21 @@ import { appTitle } from '../resources/constants'
 
 // Mock MainAccordion to capture its props for testing
 jest.mock('../components/MainAccordion', () => (props) => {
-  return <div data-testid="main-accordion">{JSON.stringify(props)}</div>
+  return <div data-testid='main-accordion'>{JSON.stringify(props)}</div>
 })
 
 describe('MainLayout', () => {
   test('calls fetchPostings when it renders', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps) // Mocking the function to resolve with an array
 
-    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
+    render(
+      <MainLayout
+        isStudent
+        isFaculty={false}
+        isAdmin={false}
+        fetchPostings={mockFetchPostings}
+      />
+    )
 
     await waitFor(() => {
       expect(mockFetchPostings).toHaveBeenCalledWith(true, false, false) // Verify the mock function was called with the correct arguments
@@ -23,7 +30,14 @@ describe('MainLayout', () => {
   test('renders app title', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps)
 
-    render(<MainLayout isStudent={true} isFaculty={false} isAdmin={false} fetchPostings={mockFetchPostings} />)
+    render(
+      <MainLayout
+        isStudent
+        isFaculty={false}
+        isAdmin={false}
+        fetchPostings={mockFetchPostings}
+      />
+    )
 
     await waitFor(() => {
       const title = screen.getByRole('button', { name: appTitle })
@@ -46,7 +60,14 @@ describe('MainLayout', () => {
   // New test: verifies that MainAccordion receives the correct props from MainLayout
   test('passes correct props to MainAccordion', async () => {
     const mockFetchPostings = jest.fn().mockResolvedValue(mockResearchOps)
-    render(<MainLayout isStudent={true} isFaculty={true} isAdmin={false} fetchPostings={mockFetchPostings} />)
+    render(
+      <MainLayout
+        isStudent
+        isFaculty
+        isAdmin={false}
+        fetchPostings={mockFetchPostings}
+      />
+    )
 
     await waitFor(() => {
       expect(screen.getByTestId('main-accordion')).toBeInTheDocument()

--- a/frontend/src/__tests__/MajorAccordion.test.js
+++ b/frontend/src/__tests__/MajorAccordion.test.js
@@ -4,30 +4,34 @@ import MajorAccordion from '../components/MajorAccordion'
 import { mockMajorNoPosts, mockMajorOnePost } from '../resources/mockData'
 
 describe('MajorAccordion', function () {
-  function getMockSetSelectedPost () {
+  function getMockSetSelectedPost() {
     return jest.fn()
   }
 
-  it('renders major name with 0 opportunities', function () {
+  it('renders major name with 0 opportunities (student view)', function () {
     render(
       <MajorAccordion
         major={mockMajorNoPosts}
         numPosts={mockMajorNoPosts.posts.length}
         setSelectedPost={getMockSetSelectedPost()}
-        isStudent
+        isStudent={true}
+        isFaculty={false}
+        isAdmin={false}
       />
     )
     expect(screen.getByText(mockMajorNoPosts.name)).toBeInTheDocument()
     expect(screen.getByText('(0 opportunities)')).toBeInTheDocument()
   })
 
-  it('renders major name and posts when present', function () {
+  it('renders major name and posts when present (student view)', function () {
     render(
       <MajorAccordion
         major={mockMajorOnePost}
         numPosts={mockMajorOnePost.posts.length}
         setSelectedPost={getMockSetSelectedPost()}
-        isStudent
+        isStudent={true}
+        isFaculty={false}
+        isAdmin={false}
       />
     )
 
@@ -37,8 +41,6 @@ describe('MajorAccordion', function () {
     })
 
     expect(majorButton).toBeInTheDocument()
-
-    // Check for the major name within the summary (button)
     expect(within(majorButton).getByText(mockMajorOnePost.name)).toBeInTheDocument()
 
     // Expand the accordion
@@ -46,11 +48,82 @@ describe('MajorAccordion', function () {
       majorButton.click()
     })
 
-    // After expansion, find the region and check for the post name
+    // After expansion, find the region and check for the post name (student view renders post.name)
     const accordionRegion = screen.getByRole('region')
     expect(accordionRegion).toBeInTheDocument()
 
     const postName = mockMajorOnePost.posts[0].name
     expect(within(accordionRegion).getByText(postName)).toBeInTheDocument()
+  })
+
+  // New test for faculty view with no posts
+  it('renders major name with correct label for faculty view (0 posts)', function () {
+    render(
+      <MajorAccordion
+        major={mockMajorNoPosts}
+        numPosts={mockMajorNoPosts.posts.length}
+        setSelectedPost={getMockSetSelectedPost()}
+        isStudent={false}
+        isFaculty={true}
+        isAdmin={false}
+      />
+    )
+    expect(screen.getByText(mockMajorNoPosts.name)).toBeInTheDocument()
+    expect(screen.getByText('(0 students)')).toBeInTheDocument()
+  })
+
+  // Updated test for faculty view: verifies that the faculty details are rendered
+  it('renders major name and posts when present for faculty view', function () {
+    // Create a custom faculty post with the expected fields for faculty view
+    const facultyPost = {
+      id: 201,
+      firstName: "Test",
+      lastName: "User",
+      classStatus: "Senior",
+      graduationYear: 2025,
+      email: "test@domain.com",
+      majors: ["Sociology"],
+      isActive: true
+    }
+    // Create a modified major object for faculty view using the faculty post
+    const facultyMajor = {
+      ...mockMajorOnePost,
+      posts: [facultyPost]
+    }
+
+    render(
+      <MajorAccordion
+        major={facultyMajor}
+        numPosts={facultyMajor.posts.length}
+        setSelectedPost={getMockSetSelectedPost()}
+        isStudent={false}
+        isFaculty={true}
+        isAdmin={false}
+      />
+    )
+
+    // Find the expandable summary button with label showing "students"
+    const majorButton = screen.getByRole('button', {
+      name: new RegExp(`${facultyMajor.name}.*\\(${facultyMajor.posts.length} students\\)`, 'i')
+    })
+
+    expect(majorButton).toBeInTheDocument()
+    expect(within(majorButton).getByText(facultyMajor.name)).toBeInTheDocument()
+
+    // Expand the accordion
+    act(() => {
+      majorButton.click()
+    })
+
+    // After expansion, find the region and check for the faculty details
+    const accordionRegion = screen.getByRole('region')
+    expect(accordionRegion).toBeInTheDocument()
+
+    // Check that the combined first and last name is rendered
+    expect(within(accordionRegion).getByText("Test User")).toBeInTheDocument()
+    expect(within(accordionRegion).getByText(/Class Status: Senior/)).toBeInTheDocument()
+    expect(within(accordionRegion).getByText(/Graduation Year: 2025/)).toBeInTheDocument()
+    expect(within(accordionRegion).getByText(/Email: test@domain.com/)).toBeInTheDocument()
+    expect(within(accordionRegion).getByText(/Majors: Sociology/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/MajorAccordion.test.js
+++ b/frontend/src/__tests__/MajorAccordion.test.js
@@ -4,7 +4,7 @@ import MajorAccordion from '../components/MajorAccordion'
 import { mockMajorNoPosts, mockMajorOnePost } from '../resources/mockData'
 
 describe('MajorAccordion', function () {
-  function getMockSetSelectedPost() {
+  function getMockSetSelectedPost () {
     return jest.fn()
   }
 
@@ -14,7 +14,7 @@ describe('MajorAccordion', function () {
         major={mockMajorNoPosts}
         numPosts={mockMajorNoPosts.posts.length}
         setSelectedPost={getMockSetSelectedPost()}
-        isStudent={true}
+        isStudent
         isFaculty={false}
         isAdmin={false}
       />
@@ -29,7 +29,7 @@ describe('MajorAccordion', function () {
         major={mockMajorOnePost}
         numPosts={mockMajorOnePost.posts.length}
         setSelectedPost={getMockSetSelectedPost()}
-        isStudent={true}
+        isStudent
         isFaculty={false}
         isAdmin={false}
       />
@@ -64,7 +64,7 @@ describe('MajorAccordion', function () {
         numPosts={mockMajorNoPosts.posts.length}
         setSelectedPost={getMockSetSelectedPost()}
         isStudent={false}
-        isFaculty={true}
+        isFaculty
         isAdmin={false}
       />
     )
@@ -77,12 +77,12 @@ describe('MajorAccordion', function () {
     // Create a custom faculty post with the expected fields for faculty view
     const facultyPost = {
       id: 201,
-      firstName: "Test",
-      lastName: "User",
-      classStatus: "Senior",
+      firstName: 'Test',
+      lastName: 'User',
+      classStatus: 'Senior',
       graduationYear: 2025,
-      email: "test@domain.com",
-      majors: ["Sociology"],
+      email: 'test@domain.com',
+      majors: ['Sociology'],
       isActive: true
     }
     // Create a modified major object for faculty view using the faculty post
@@ -97,7 +97,7 @@ describe('MajorAccordion', function () {
         numPosts={facultyMajor.posts.length}
         setSelectedPost={getMockSetSelectedPost()}
         isStudent={false}
-        isFaculty={true}
+        isFaculty
         isAdmin={false}
       />
     )
@@ -120,7 +120,7 @@ describe('MajorAccordion', function () {
     expect(accordionRegion).toBeInTheDocument()
 
     // Check that the combined first and last name is rendered
-    expect(within(accordionRegion).getByText("Test User")).toBeInTheDocument()
+    expect(within(accordionRegion).getByText('Test User')).toBeInTheDocument()
     expect(within(accordionRegion).getByText(/Class Status: Senior/)).toBeInTheDocument()
     expect(within(accordionRegion).getByText(/Graduation Year: 2025/)).toBeInTheDocument()
     expect(within(accordionRegion).getByText(/Email: test@domain.com/)).toBeInTheDocument()

--- a/frontend/src/__tests__/PostList.test.js
+++ b/frontend/src/__tests__/PostList.test.js
@@ -31,7 +31,7 @@ describe('PostList', () => {
       <PostList
         postings={[]}
         setSelectedPost={mockSetSelectedPost}
-        isStudent={true} // TODO
+        isStudent // TODO
       />
     )
 
@@ -43,7 +43,7 @@ describe('PostList', () => {
       <PostList
         postings={mockTwoInactiveProjects}
         setSelectedPost={mockSetSelectedPost}
-        isStudent={true} // TODO true
+        isStudent // TODO true
       />
     )
 
@@ -57,7 +57,7 @@ describe('PostList', () => {
       <PostList
         postings={mockThreeActiveProjects}
         setSelectedPost={mockSetSelectedPost}
-        isStudent={true} // true
+        isStudent // true
       />
     )
 
@@ -83,7 +83,7 @@ describe('PostList', () => {
       <PostList
         postings={mockThreeActiveProjects}
         setSelectedPost={mockSetSelectedPost}
-        isStudent={true} // TODO
+        isStudent // TODO
       />
     )
 
@@ -105,12 +105,12 @@ describe('PostList', () => {
     const mockFacultyPostings = [
       {
         id: 0,
-        firstName: "Augusto",
-        lastName: "Escudero",
-        email: "aescudero@sandiego.edu",
-        classStatus: "Senior",
+        firstName: 'Augusto',
+        lastName: 'Escudero',
+        email: 'aescudero@sandiego.edu',
+        classStatus: 'Senior',
         graduationYear: 2025,
-        majors: ["Computer Science"],
+        majors: ['Computer Science'],
         isActive: true
       }
     ]
@@ -120,11 +120,11 @@ describe('PostList', () => {
         postings={mockFacultyPostings}
         setSelectedPost={mockSetSelectedPost}
         isStudent={false}
-        isFaculty={true}
+        isFaculty
       />
     )
 
-    expect(screen.getByText("Augusto Escudero")).toBeInTheDocument()
+    expect(screen.getByText('Augusto Escudero')).toBeInTheDocument()
     expect(screen.getByText(/Class Status: Senior/)).toBeInTheDocument()
     expect(screen.getByText(/Graduation Year: 2025/)).toBeInTheDocument()
     expect(screen.getByText(/Email: aescudero@sandiego.edu/)).toBeInTheDocument()

--- a/frontend/src/__tests__/PostList.test.js
+++ b/frontend/src/__tests__/PostList.test.js
@@ -12,12 +12,14 @@ describe('PostList', () => {
     jest.clearAllMocks()
   })
 
-  test('renders no postings message if not a student', () => {
+  test('renders no postings message if not a student or faculty', () => {
     render(
       <PostList
         postings={mockThreeActiveProjects}
         setSelectedPost={mockSetSelectedPost}
         isStudent={false}
+        isFaculty={false}
+        isAdmin={false}
       />
     )
 
@@ -29,7 +31,7 @@ describe('PostList', () => {
       <PostList
         postings={[]}
         setSelectedPost={mockSetSelectedPost}
-        isStudent
+        isStudent={true} // TODO
       />
     )
 
@@ -41,19 +43,21 @@ describe('PostList', () => {
       <PostList
         postings={mockTwoInactiveProjects}
         setSelectedPost={mockSetSelectedPost}
-        isStudent
+        isStudent={true} // TODO true
       />
     )
 
     expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
   })
 
+  // TODO this test but renders students for faculty
+
   test('renders active postings with correct details for students', () => {
     render(
       <PostList
         postings={mockThreeActiveProjects}
         setSelectedPost={mockSetSelectedPost}
-        isStudent
+        isStudent={true} // true
       />
     )
 
@@ -79,7 +83,7 @@ describe('PostList', () => {
       <PostList
         postings={mockThreeActiveProjects}
         setSelectedPost={mockSetSelectedPost}
-        isStudent
+        isStudent={true} // TODO
       />
     )
 
@@ -92,5 +96,38 @@ describe('PostList', () => {
 
     expect(mockSetSelectedPost).toHaveBeenCalledTimes(1)
     expect(mockSetSelectedPost).toHaveBeenCalledWith(firstProject)
+  })
+
+  // New test for faculty view:
+  // Verifies that when isFaculty is true and isStudent is false,
+  // the component renders firstName, lastName, classStatus, graduationYear, majors, and email.
+  test('renders active postings with correct details for faculty', () => {
+    const mockFacultyPostings = [
+      {
+        id: 0,
+        firstName: "Augusto",
+        lastName: "Escudero",
+        email: "aescudero@sandiego.edu",
+        classStatus: "Senior",
+        graduationYear: 2025,
+        majors: ["Computer Science"],
+        isActive: true
+      }
+    ]
+
+    render(
+      <PostList
+        postings={mockFacultyPostings}
+        setSelectedPost={mockSetSelectedPost}
+        isStudent={false}
+        isFaculty={true}
+      />
+    )
+
+    expect(screen.getByText("Augusto Escudero")).toBeInTheDocument()
+    expect(screen.getByText(/Class Status: Senior/)).toBeInTheDocument()
+    expect(screen.getByText(/Graduation Year: 2025/)).toBeInTheDocument()
+    expect(screen.getByText(/Email: aescudero@sandiego.edu/)).toBeInTheDocument()
+    expect(screen.getByText(/Majors: Computer Science/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/MainAccordion.js
+++ b/frontend/src/components/MainAccordion.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types'
 function MainAccordion ({ postings, setSelectedPost, isStudent }) {
   // renderMajors handles the logic for displaying majors of a given department
   const renderMajors = (department) => {
-    if (!isStudent || department.majors.length === 0) {
+    if (department.majors.length === 0) {
       return (
         <Typography style={{ padding: '16px' }}>
           {noPostsMessage}
@@ -32,6 +32,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent }) {
       />
     ))
   }
+
   // Render departments logic:
   // If no postings it shows an error message
   // Otherwise, it creates an accordion for each department

--- a/frontend/src/components/MainAccordion.js
+++ b/frontend/src/components/MainAccordion.js
@@ -1,6 +1,6 @@
 /**
- * @file Logic and renders for majors of given department in an accordion style where there are dropdowns
- * for each department and within each department there are dropdowns for each major.Uses Material UI.
+ * @file Logic and renders for majors of given discipline in an accordion style where there are dropdowns
+ * for each discipline and within each discipline there are dropdowns for each major.Uses Material UI.
  * @author Eduardo Perez Rocha <eperezrocha@sandiego.edu>
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */
@@ -11,10 +11,10 @@ import MajorAccordion from './MajorAccordion'
 import { errorLoadingPostingsMessage, noPostsMessage } from '../resources/constants'
 import PropTypes from 'prop-types'
 
-function MainAccordion ({ postings, setSelectedPost, isStudent }) {
-  // renderMajors handles the logic for displaying majors of a given department
-  const renderMajors = (department) => {
-    if (department.majors.length === 0) {
+function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin }) {
+  // renderMajors handles the logic for displaying majors of a given discipline
+  const renderMajors = (discipline) => {
+    if (discipline.majors.length === 0) {
       return (
         <Typography style={{ padding: '16px' }}>
           {noPostsMessage}
@@ -22,28 +22,30 @@ function MainAccordion ({ postings, setSelectedPost, isStudent }) {
       )
     }
 
-    return department.majors.map((major) => (
+    return discipline.majors.map((major) => (
       <MajorAccordion
         key={major.id}
         major={major}
         numPosts={major.posts.length}
         setSelectedPost={setSelectedPost}
         isStudent={isStudent}
+        isFaculty={isFaculty}
+        isAdmin={isAdmin}
       />
     ))
   }
 
-  // Render departments logic:
+  // Render disciplines logic:
   // If no postings it shows an error message
-  // Otherwise, it creates an accordion for each department
-  const renderDepartments = () => {
+  // Otherwise, it creates an accordion for each discipline
+  const renderdisciplines = () => {
     if (postings.length === 0) {
       return <Typography>{errorLoadingPostingsMessage}</Typography>
     }
 
-    return postings.map((department) => (
+    return postings.map((discipline) => (
       <Accordion
-        key={`dept-${department.id}`}
+        key={`dept-${discipline.id}`}
         disableGutters
         sx={{
           mb: 2,
@@ -65,8 +67,8 @@ function MainAccordion ({ postings, setSelectedPost, isStudent }) {
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls={`panel${department.id}-content`}
-          id={`panel${department.id}-header`}
+          aria-controls={`panel${discipline.id}-content`}
+          id={`panel${discipline.id}-header`}
           sx={{
             bgcolor: '#F0F0F0',
             borderRadius: '8px !important',
@@ -81,7 +83,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent }) {
         >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Typography sx={{ fontWeight: 'bold' }}>
-              {department.name}
+              {discipline.name}
             </Typography>
           </Box>
         </AccordionSummary>
@@ -95,7 +97,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent }) {
             borderRadius: '0 0 8px 8px'
           }}
         >
-          {renderMajors(department)}
+          {renderMajors(discipline)}
         </AccordionDetails>
       </Accordion>
     ))
@@ -103,7 +105,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent }) {
 
   return (
     <Box sx={{ p: 2, borderRadius: 2 }}>
-      {renderDepartments()}
+      {renderdisciplines()}
     </Box>
   )
 }

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -5,7 +5,7 @@
  * @author Sharthok Rayan <rpal@sandiego.edu>
  */
 import React, { useState, useEffect } from 'react'
-import { Box, Typography } from '@mui/material'
+import { Box } from '@mui/material'
 import MainAccordion from './MainAccordion'
 import PostDialog from './PostDialog'
 import TitleButton from './TitleButton'
@@ -35,7 +35,7 @@ function MainLayout ({ fetchPostings, isStudent, isFaculty, isAdmin }) {
           flexDirection: 'row', // Horizontal layout
           justifyContent: 'space-between', // Distribute components evenly with space between them
           alignItems: 'center', // Vertically center items if necessary
-          padding: 2,
+          padding: 2
         }}
       >
         {/* Header */}
@@ -56,7 +56,7 @@ function MainLayout ({ fetchPostings, isStudent, isFaculty, isAdmin }) {
           display: 'flex',
           flexDirection: 'row', // Horizontal layout
           gap: 2, // Space between components
-          padding: 2,
+          padding: 2
         }}
       >
         {/* Sidebar */}
@@ -65,17 +65,16 @@ function MainLayout ({ fetchPostings, isStudent, isFaculty, isAdmin }) {
 
         {/* Main content */}
         <Box sx={{ width: '75%' }}>
-
           <MainAccordion
             sx={{
               maxHeight: { xs: '400px', md: '600px' },
               overflowY: 'auto',
               '&::-webkit-scrollbar': {
-                width: '8px',
+                width: '8px'
               },
               '&::-webkit-scrollbar-thumb': {
-                borderRadius: '4px',
-              },
+                borderRadius: '4px'
+              }
             }}
             postings={postings}
             setSelectedPost={setSelectedPost}
@@ -87,12 +86,12 @@ function MainLayout ({ fetchPostings, isStudent, isFaculty, isAdmin }) {
         </Box>
       </Box>
     </Box>
-  );
+  )
 }
 
 MainLayout.propTypes = {
   isStudent: PropTypes.bool.isRequired,
-  fetchPostings: PropTypes.func.isRequired,
-};
+  fetchPostings: PropTypes.func.isRequired
+}
 
 export default MainLayout

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -80,6 +80,8 @@ function MainLayout ({ fetchPostings, isStudent, isFaculty, isAdmin }) {
             postings={postings}
             setSelectedPost={setSelectedPost}
             isStudent={isStudent}
+            isFaculty={isFaculty}
+            isAdmin={isAdmin}
           />
           <PostDialog post={selectedPost} onClose={() => setSelectedPost(null)} />
         </Box>

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -5,7 +5,7 @@
  * @author Sharthok Rayan <rpal@sandiego.edu>
  */
 import React, { useState, useEffect } from 'react'
-import { Box } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import MainAccordion from './MainAccordion'
 import PostDialog from './PostDialog'
 import TitleButton from './TitleButton'
@@ -14,25 +14,20 @@ import ViewProfile from './ViewProfile'
 import Sidebar from './Sidebar'
 import PropTypes from 'prop-types'
 
-function MainLayout ({ isStudent, fetchPostings }) {
+function MainLayout({ fetchPostings, isStudent, isFaculty, isAdmin }) {
   const [selectedPost, setSelectedPost] = useState(null)
   const [postings, setPostings] = useState([])
 
   useEffect(() => {
     const fetchData = async () => {
-      const posts = await fetchPostings(isStudent)
+      const posts = await fetchPostings(isStudent, isFaculty, isAdmin)
       setPostings(posts)
     }
     fetchData()
-  }, [fetchPostings, isStudent])
+  }, [fetchPostings, isStudent, isFaculty, isAdmin]);
 
   return (
-    <Box sx={{
-      minHeight: '100vh',
-      bgcolor: '#FAFAFA'
-    }}
-    >
-
+    <Box sx={{ minHeight: '100vh', bgcolor: '#FAFAFA' }}>
       {/* The outermost box that puts the header, search bar, and view profile button next to each other */}
       <Box
         sx={{
@@ -40,7 +35,7 @@ function MainLayout ({ isStudent, fetchPostings }) {
           flexDirection: 'row', // Horizontal layout
           justifyContent: 'space-between', // Distribute components evenly with space between them
           alignItems: 'center', // Vertically center items if necessary
-          padding: 2
+          padding: 2,
         }}
       >
         {/* Header */}
@@ -53,7 +48,6 @@ function MainLayout ({ isStudent, fetchPostings }) {
         {/* View profile button */}
         {/* TO BE ADDED IN LATER SPRINTS - EDIT SEPARATE COMPONENT */}
         <ViewProfile />
-
       </Box>
 
       {/* The outermost box that puts the sidebar and the tabs next to each other */}
@@ -62,7 +56,7 @@ function MainLayout ({ isStudent, fetchPostings }) {
           display: 'flex',
           flexDirection: 'row', // Horizontal layout
           gap: 2, // Space between components
-          padding: 2
+          padding: 2,
         }}
       >
         {/* Sidebar */}
@@ -71,42 +65,32 @@ function MainLayout ({ isStudent, fetchPostings }) {
 
         {/* Main content */}
         <Box sx={{ width: '75%' }}>
-          {/* Added header for professor view */}
-          {!isStudent && (
-            <Typography variant='h5' sx={{ mb: 2 }}>
-              Student Listings
-            </Typography>
-          )}
 
           <MainAccordion
             sx={{
               maxHeight: { xs: '400px', md: '600px' },
               overflowY: 'auto',
               '&::-webkit-scrollbar': {
-                width: '8px'
+                width: '8px',
               },
               '&::-webkit-scrollbar-thumb': {
-                borderRadius: '4px'
-              }
+                borderRadius: '4px',
+              },
             }}
             postings={postings}
             setSelectedPost={setSelectedPost}
             isStudent={isStudent}
           />
-          <PostDialog
-            post={selectedPost}
-            onClose={() => setSelectedPost(null)}
-          />
-
+          <PostDialog post={selectedPost} onClose={() => setSelectedPost(null)} />
         </Box>
       </Box>
     </Box>
-  )
+  );
 }
 
 MainLayout.propTypes = {
   isStudent: PropTypes.bool.isRequired,
-  fetchPostings: PropTypes.func.isRequired
-}
+  fetchPostings: PropTypes.func.isRequired,
+};
 
 export default MainLayout

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -71,6 +71,12 @@ function MainLayout ({ isStudent, fetchPostings }) {
 
         {/* Main content */}
         <Box sx={{ width: '75%' }}>
+          {/* Added header for professor view */}
+          {!isStudent && (
+            <Typography variant='h5' sx={{ mb: 2 }}>
+              Student Listings
+            </Typography>
+          )}
 
           <MainAccordion
             sx={{

--- a/frontend/src/components/MajorAccordion.js
+++ b/frontend/src/components/MajorAccordion.js
@@ -10,7 +10,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import PostList from './PostList'
 import PropTypes from 'prop-types'
 
-function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent, isFaculty, isAdmin}) {
+function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent, isFaculty, isAdmin }) {
   return (
     // Disable and remove the expand icon if there are no posts
     <Accordion disableGutters disabled={numPosts === 0}>

--- a/frontend/src/components/MajorAccordion.js
+++ b/frontend/src/components/MajorAccordion.js
@@ -21,10 +21,7 @@ function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent }) {
         sx={{ bgcolor: '#FAFAFA' }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <Typography
-            data-testid='major-name'
-            sx={{ fontWeight: 'bold' }}
-          >
+          <Typography data-testid='major-name' sx={{ fontWeight: 'bold' }}>
             {major.name}
           </Typography>
           <Typography
@@ -37,11 +34,7 @@ function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent }) {
       </AccordionSummary>
       {numPosts > 0 && (
         <AccordionDetails>
-          <PostList
-            postings={major.posts}
-            setSelectedPost={setSelectedPost}
-            isStudent={isStudent}
-          />
+          <PostList postings={major.posts} setSelectedPost={setSelectedPost} isStudent={isStudent} />
         </AccordionDetails>
       )}
     </Accordion>

--- a/frontend/src/components/MajorAccordion.js
+++ b/frontend/src/components/MajorAccordion.js
@@ -31,7 +31,7 @@ function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent }) {
             variant='body2'
             sx={{ color: 'gray', fontSize: '0.875rem', marginLeft: 1, fontWeight: 'normal' }}
           >
-            ({numPosts} opportunities)
+            ({numPosts} {isStudent ? 'opportunities' : 'students'})
           </Typography>
         </Box>
       </AccordionSummary>

--- a/frontend/src/components/MajorAccordion.js
+++ b/frontend/src/components/MajorAccordion.js
@@ -10,7 +10,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import PostList from './PostList'
 import PropTypes from 'prop-types'
 
-function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent }) {
+function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent, isFaculty, isAdmin}) {
   return (
     // Disable and remove the expand icon if there are no posts
     <Accordion disableGutters disabled={numPosts === 0}>
@@ -34,7 +34,7 @@ function MajorAccordion ({ major, numPosts, setSelectedPost, isStudent }) {
       </AccordionSummary>
       {numPosts > 0 && (
         <AccordionDetails>
-          <PostList postings={major.posts} setSelectedPost={setSelectedPost} isStudent={isStudent} />
+          <PostList postings={major.posts} setSelectedPost={setSelectedPost} isStudent={isStudent} isFaculty={isFaculty} isAdmin={isAdmin} />
         </AccordionDetails>
       )}
     </Accordion>
@@ -49,7 +49,10 @@ MajorAccordion.propTypes = {
   }).isRequired,
   numPosts: PropTypes.number.isRequired,
   setSelectedPost: PropTypes.func.isRequired,
-  isStudent: PropTypes.bool.isRequired
+  isStudent: PropTypes.bool.isRequired,
+  isFaculty: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool.isRequired
+
 }
 
 export default MajorAccordion

--- a/frontend/src/components/PostList.js
+++ b/frontend/src/components/PostList.js
@@ -2,6 +2,7 @@
  * @file Renders postings with the umbrella topics and oppportunites if there are any
  * @author Eduardo Perez Rocha <eperezrocha@sandiego.edu>
  * @author Natalie Jungquist <njungquist@sandiego.edu>
+ * @author Rayan Pal <rpal@sandiego.edu>
  */
 import React from 'react'
 import {
@@ -19,11 +20,11 @@ import LocalOfferIcon from '@mui/icons-material/LocalOffer'
 import { noPostsMessage } from '../resources/constants'
 import PropTypes from 'prop-types'
 
-function PostList ({ postings, setSelectedPost, isStudent }) {
+function PostList({ postings, setSelectedPost, isStudent, isFaculty, isAdmin }) {
   // Filter out inactive postings.
   const activePostings = postings.filter((post) => post.isActive)
 
-  if (!isStudent || postings.length === 0) {
+  if (postings.length === 0) {
     return (
       <Box sx={{ p: 2 }}>
         <Typography sx={{ p: 2 }}>{noPostsMessage}</Typography>
@@ -39,75 +40,60 @@ function PostList ({ postings, setSelectedPost, isStudent }) {
     )
   }
 
-  return (
-    <Box sx={{ p: 2 }}>
-      <Stack spacing={2}>
-        {activePostings.map((post) => (
-          <Card
-            key={`post-${post.id}`}
-            onClick={() => setSelectedPost(post)}
-            sx={{
-              cursor: 'pointer',
-              '&:hover': {
-                boxShadow: 3
-              },
-              position: 'relative'
-            }}
-          >
-            <CardContent>
-              <IconButton
-                sx={{
-                  position: 'absolute',
-                  right: 8,
-                  top: 8,
-                  color: 'action.active'
-                }}
-              >
-                <EmailIcon />
-              </IconButton>
+  // if isStudent: render research name, faculty name, umbrella topics
+  // if isFaculty: render first name, last name, classStatus, graduationYear, majors, email
+  if (isStudent) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          {activePostings.map((post) => (
+            <Card
+              key={`post-${post.id}`}
+              onClick={() => setSelectedPost(post)}
+              sx={{
+                cursor: 'pointer',
+                '&:hover': {
+                  boxShadow: 3
+                },
+                position: 'relative'
+              }}
+            >
+              <CardContent>
+                <IconButton
+                  sx={{
+                    position: 'absolute',
+                    right: 8,
+                    top: 8,
+                    color: 'action.active'
+                  }}
+                >
+                  <EmailIcon />
+                </IconButton>
 
-              <Typography variant='h7' fontWeight='bold' component='div' sx={{ mb: 1, pr: 5 }}>
-                {post.name}
-              </Typography>
+                <Typography variant='h7' fontWeight='bold' component='div' sx={{ mb: 1, pr: 5 }}>
+                  {post.name}
+                </Typography>
 
-              <Typography
-                sx={{
-                  color: 'text.secondary',
-                  mb: 2
-                }}
-                variant='body2'
-              >
-                {post.faculty.firstName} {post.faculty.lastName}
-                &nbsp;&nbsp;•&nbsp;&nbsp;
-                {post.researchPeriods.join(', ')}
-              </Typography>
+                <Typography
+                  sx={{
+                    color: 'text.secondary',
+                    mb: 2
+                  }}
+                  variant='body2'
+                >
+                  {post.faculty.firstName} {post.faculty.lastName}
+                  &nbsp;&nbsp;•&nbsp;&nbsp;
+                  {post.researchPeriods.join(', ')}
+                </Typography>
 
-              <Stack spacing={1}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <SchoolIcon color='action' fontSize='small' />
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                    {post.majors?.map((major, index) => (
-                      <Chip
-                        key={index}
-                        label={major}
-                        size='small'
-                        sx={{
-                          bgcolor: 'grey.100',
-                          height: '24px'
-                        }}
-                      />
-                    ))}
-                  </Box>
-                </Box>
-
-                {post.umbrellaTopics?.length > 0 && (
+                <Stack spacing={1}>
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <LocalOfferIcon color='action' fontSize='small' />
+                    <SchoolIcon color='action' fontSize='small' />
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                      {post.umbrellaTopics.slice(0, 3).map((topic, index) => (
+                      {post.majors?.map((major, index) => (
                         <Chip
                           key={index}
-                          label={topic}
+                          label={major}
                           size='small'
                           sx={{
                             bgcolor: 'grey.100',
@@ -115,31 +101,96 @@ function PostList ({ postings, setSelectedPost, isStudent }) {
                           }}
                         />
                       ))}
-                      {post.umbrellaTopics.length > 3 && (
-                        <Typography
-                          variant='body2'
-                          color='primary'
-                          sx={{ alignSelf: 'center' }}
-                        >
-                          +{post.umbrellaTopics.length - 3} more
-                        </Typography>
-                      )}
                     </Box>
                   </Box>
-                )}
-              </Stack>
-            </CardContent>
-          </Card>
-        ))}
-      </Stack>
-    </Box>
-  )
+
+                  {post.umbrellaTopics?.length > 0 && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <LocalOfferIcon color='action' fontSize='small' />
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                        {post.umbrellaTopics.slice(0, 3).map((topic, index) => (
+                          <Chip
+                            key={index}
+                            label={topic}
+                            size='small'
+                            sx={{
+                              bgcolor: 'grey.100',
+                              height: '24px'
+                            }}
+                          />
+                        ))}
+                        {post.umbrellaTopics.length > 3 && (
+                          <Typography
+                            variant='body2'
+                            color='primary'
+                            sx={{ alignSelf: 'center' }}
+                          >
+                            +{post.umbrellaTopics.length - 3} more
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  )}
+                </Stack>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      </Box>
+    )
+  } else if (isFaculty) {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Stack spacing={2}>
+          {activePostings.map((post) => (
+            <Card
+              key={`post-${post.id}`}
+              onClick={() => setSelectedPost(post)}
+              sx={{
+                cursor: 'pointer',
+                '&:hover': {
+                  boxShadow: 3
+                },
+                position: 'relative'
+              }}
+            >
+              <CardContent>
+                <Typography variant='h7' fontWeight='bold' component='div' sx={{ mb: 1, pr: 5 }}>
+                  {post.firstName} {post.lastName}
+                </Typography>
+                <Typography variant='body2' sx={{ mb: 1 }}>
+                  Class Status: {post.classStatus}
+                </Typography>
+                <Typography variant='body2' sx={{ mb: 1 }}>
+                  Graduation Year: {post.graduationYear}
+                </Typography>
+                <Typography variant='body2' sx={{ mb: 1 }}>
+                  Email: {post.email}
+                </Typography>
+                <Typography variant='body2'>
+                  Majors: {Array.isArray(post.majors) ? post.majors.join(', ') : post.majors}
+                </Typography>
+              </CardContent>
+            </Card>
+          ))}
+        </Stack>
+      </Box>
+    )
+  } else {
+    return (
+      <Box sx={{ p: 2 }}>
+        <Typography sx={{ p: 2 }}>{noPostsMessage}</Typography>
+      </Box>
+    )
+  }
 }
 
 PostList.propTypes = {
   postings: PropTypes.array.isRequired,
   setSelectedPost: PropTypes.func.isRequired,
-  isStudent: PropTypes.bool.isRequired
+  isStudent: PropTypes.bool.isRequired,
+  isFaculty: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool,
 }
 
 export default PostList

--- a/frontend/src/components/PostList.js
+++ b/frontend/src/components/PostList.js
@@ -20,7 +20,7 @@ import LocalOfferIcon from '@mui/icons-material/LocalOffer'
 import { noPostsMessage } from '../resources/constants'
 import PropTypes from 'prop-types'
 
-function PostList({ postings, setSelectedPost, isStudent, isFaculty, isAdmin }) {
+function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin }) {
   // Filter out inactive postings.
   const activePostings = postings.filter((post) => post.isActive)
 
@@ -190,7 +190,7 @@ PostList.propTypes = {
   setSelectedPost: PropTypes.func.isRequired,
   isStudent: PropTypes.bool.isRequired,
   isFaculty: PropTypes.bool.isRequired,
-  isAdmin: PropTypes.bool,
+  isAdmin: PropTypes.bool
 }
 
 export default PostList

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -132,73 +132,72 @@ export const mockMajorOnePost = {
 
 export const mockStudents = [
   {
-    "id": 1,
-    "name": "Engineering, Math, and Computer Science",
-    "majors": [
+    id: 1,
+    name: 'Engineering, Math, and Computer Science',
+    majors: [
       {
-        "id": 1,
-        "name": "Computer Science",
-        "posts": null,
-        "students": [
+        id: 1,
+        name: 'Computer Science',
+        posts: null,
+        students: [
           {
-            "id": 0,
-            "firstName": "Augusto",
-            "lastName": "Escudero",
-            "email": "aescudero@sandiego.edu",
-            "classStatus": "Senior",
-            "graduationYear": 2025,
-            "majors": [
-              "Computer Science"
+            id: 0,
+            firstName: 'Augusto',
+            lastName: 'Escudero',
+            email: 'aescudero@sandiego.edu',
+            classStatus: 'Senior',
+            graduationYear: 2025,
+            majors: [
+              'Computer Science'
             ],
-            "researchFieldInterests": [
-              "Chemistry",
-              "Computer Science"
+            researchFieldInterests: [
+              'Chemistry',
+              'Computer Science'
             ],
-            "researchPeriodsInterest": [
-              "Fall 2025"
+            researchPeriodsInterest: [
+              'Fall 2025'
             ],
-            "interestReason": "Test reason",
-            "hasPriorExperience": true
+            interestReason: 'Test reason',
+            hasPriorExperience: true
           }
         ]
       }
     ]
   },
   {
-    "id": 2,
-    "name": "Life and Physical Sciences",
-    "majors": [
+    id: 2,
+    name: 'Life and Physical Sciences',
+    majors: [
       {
-        "id": 2,
-        "name": "Chemistry",
-        "posts": null,
-        "students": [
+        id: 2,
+        name: 'Chemistry',
+        posts: null,
+        students: [
           {
-            "id": 0,
-            "firstName": "Augusto",
-            "lastName": "Escudero",
-            "email": "aescudero@sandiego.edu",
-            "classStatus": "Senior",
-            "graduationYear": 2025,
-            "majors": [
-              "Computer Science"
+            id: 0,
+            firstName: 'Augusto',
+            lastName: 'Escudero',
+            email: 'aescudero@sandiego.edu',
+            classStatus: 'Senior',
+            graduationYear: 2025,
+            majors: [
+              'Computer Science'
             ],
-            "researchFieldInterests": [
-              "Chemistry",
-              "Computer Science"
+            researchFieldInterests: [
+              'Chemistry',
+              'Computer Science'
             ],
-            "researchPeriodsInterest": [
-              "Fall 2025"
+            researchPeriodsInterest: [
+              'Fall 2025'
             ],
-            "interestReason": "Test reason",
-            "hasPriorExperience": true
+            interestReason: 'Test reason',
+            hasPriorExperience: true
           }
         ]
       }
     ]
   }
 ]
-
 
 export const mockResearchOps = [
   {

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -130,6 +130,76 @@ export const mockMajorOnePost = {
   ]
 }
 
+export const mockStudents = [
+  {
+    "id": 1,
+    "name": "Engineering, Math, and Computer Science",
+    "majors": [
+      {
+        "id": 1,
+        "name": "Computer Science",
+        "posts": null,
+        "students": [
+          {
+            "id": 0,
+            "firstName": "Augusto",
+            "lastName": "Escudero",
+            "email": "aescudero@sandiego.edu",
+            "classStatus": "Senior",
+            "graduationYear": 2025,
+            "majors": [
+              "Computer Science"
+            ],
+            "researchFieldInterests": [
+              "Chemistry",
+              "Computer Science"
+            ],
+            "researchPeriodsInterest": [
+              "Fall 2025"
+            ],
+            "interestReason": "Test reason",
+            "hasPriorExperience": true
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": 2,
+    "name": "Life and Physical Sciences",
+    "majors": [
+      {
+        "id": 2,
+        "name": "Chemistry",
+        "posts": null,
+        "students": [
+          {
+            "id": 0,
+            "firstName": "Augusto",
+            "lastName": "Escudero",
+            "email": "aescudero@sandiego.edu",
+            "classStatus": "Senior",
+            "graduationYear": 2025,
+            "majors": [
+              "Computer Science"
+            ],
+            "researchFieldInterests": [
+              "Chemistry",
+              "Computer Science"
+            ],
+            "researchPeriodsInterest": [
+              "Fall 2025"
+            ],
+            "interestReason": "Test reason",
+            "hasPriorExperience": true
+          }
+        ]
+      }
+    ]
+  }
+]
+
+
 export const mockResearchOps = [
   {
     id: 1,

--- a/frontend/src/utils/fetchPostings.js
+++ b/frontend/src/utils/fetchPostings.js
@@ -2,8 +2,8 @@
  * @file Function that filters for the postings to be displayed to the user.
  * The postings will either be students (if isFaculty) or research opportunities (if isStudent).
  * Returns:
- *  - all of the data for the departments
- *  - the majors under each department
+ *  - all of the data for the displines
+ *  - the majors under each displines
  *  - and the postings under each major
  *
  * @author Natalie Jungquist <njungquist@sandiego.edu>


### PR DESCRIPTION
Overview
Type of Change: New Feature

Summary:
This pull request updates the logic to ensure that the postings are rendered correctly based on the user role. Previously, the application displayed a generic student view regardless of user role. Now, when the user is a professor, the UI renders professor-specific information (first name, last name, class status, graduation year, majors, and email) instead of student opportunities. This change involved updating MainLayout.js, MainAccordion.js, MajorAccordion.js, and PostList.js, as well as adding/adjusting tests for both student and professor views.

UI/UX Implementation
The UI now conditionally displays posting details based on the user’s role:

Student view: Displays research opportunities, faculty names, and umbrella topics.
Professor view: Displays detailed student profiles (first name, last name, class status, graduation year, majors, and email).
No complete redesign was done; these changes are focused solely on ensuring the correct information is shown for each user role.
No Figma link available; the change is purely functional.
Model Updates

Data Models
No changes made.

Object-Oriented Models
No changes made.

End-to-End Testing Instructions

For a Student:

Log in as a student.
Navigate to the postings page.
Verify that the postings display the student view, which includes research opportunity names, faculty names, and umbrella topics.

For a Professor:
Log in as a professor.
Navigate to the postings page.
Verify that the postings now display professor-specific information (first name, last name, class status, graduation year, majors, and email) instead of the generic student opportunity view.