### PR TITLE
Implemented helper class to validate /projects and /students requests

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/security/UserRequestValidator.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/UserRequestValidator.java
@@ -1,0 +1,38 @@
+package COMP_49X_our_search.backend.security;
+
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.services.UserService;
+import java.util.Collections;
+import java.util.HashMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class UserRequestValidator {
+
+  private final UserService userService;
+  private final Map<UserRole, Set<String>> roleToAllowedRequests;
+
+  @Autowired
+  public UserRequestValidator(UserService userService) {
+    this.userService = userService;
+    this.roleToAllowedRequests = initializeRolePermissions();
+  }
+
+  public boolean canMakeRequest(String email, String requestType) {
+    UserRole userRole = userService.getUserRoleByEmail(email);
+
+    return roleToAllowedRequests.getOrDefault(userRole, Set.of()).contains(requestType.toLowerCase());
+  }
+
+  private Map<UserRole, Set<String>> initializeRolePermissions() {
+    Map<UserRole, Set<String>> map = new HashMap<>();
+    map.put(UserRole.STUDENT, Set.of("projects"));
+    map.put(UserRole.FACULTY, Set.of("students"));
+
+    return Collections.unmodifiableMap(map);
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/UserRequestValidatorTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/UserRequestValidatorTest.java
@@ -1,0 +1,83 @@
+package COMP_49X_our_search.backend.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import COMP_49X_our_search.backend.database.entities.User;
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.repositories.UserRepository;
+import COMP_49X_our_search.backend.database.services.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+public class UserRequestValidatorTest {
+
+  private UserRequestValidator userRequestValidator;
+  private UserRepository userRepository;
+  private UserService userService;
+  private User studentUser;
+  private User facultyUser;
+
+  @BeforeEach
+  void setUp() {
+    studentUser = new User();
+    studentUser.setEmail("student@test.com");
+    studentUser.setUserRole(UserRole.STUDENT);
+
+    facultyUser = new User();
+    facultyUser.setEmail("faculty@test.com");
+    facultyUser.setUserRole(UserRole.FACULTY);
+
+    userRepository = mock(UserRepository.class);
+    userService = new UserService(userRepository);
+    userRequestValidator = new UserRequestValidator(userService);
+  }
+
+  @Test
+  public void testCanMakeRequest_studentRequestsProjects_returnsTrue() {
+    when(userRepository.findByEmail("student@test.com")).thenReturn(Optional.of(studentUser));
+
+    assertTrue(userRequestValidator.canMakeRequest("student@test.com", "projects"));
+    verify(userRepository, times(1)).findByEmail("student@test.com");
+  }
+
+  @Test
+  public void testCanMakeRequest_studentRequestsStudents_returnsFalse() {
+    when(userRepository.findByEmail("student@test.com")).thenReturn(Optional.of(studentUser));
+
+    assertFalse(userRequestValidator.canMakeRequest("student@test.com", "students"));
+    verify(userRepository, times(1)).findByEmail("student@test.com");
+  }
+
+  @Test
+  public void testCanMakeRequest_facultyRequestsStudents_returnsTrue() {
+    when(userRepository.findByEmail("faculty@test.com")).thenReturn(Optional.of(facultyUser));
+
+    assertTrue(userRequestValidator.canMakeRequest("faculty@test.com", "students"));
+    verify(userRepository, times(1)).findByEmail("faculty@test.com");
+  }
+
+  @Test
+  public void testCanMakeRequest_facultyRequestsProjects_returnsFalse() {
+    when(userRepository.findByEmail("faculty@test.com")).thenReturn(Optional.of(facultyUser));
+
+    assertFalse(userRequestValidator.canMakeRequest("faculty@test.com", "projects"));
+    verify(userRepository, times(1)).findByEmail("faculty@test.com");
+  }
+
+  @Test
+  public void testCanMakeRequest_invalidRequestType_returnsFalse() {
+    when(userRepository.findByEmail("student@test.com")).thenReturn(Optional.of(studentUser));
+
+    assertFalse(userRequestValidator.canMakeRequest("student@test.com", "invalidRequest"));
+    verify(userRepository, times(1)).findByEmail("student@test.com");
+  }
+
+  @Test
+  public void testCanMakeRequest_invalidEmail_throwsException() {
+    assertThrows(
+        RuntimeException.class, () -> userRequestValidator.canMakeRequest(null, "projects"));
+  }
+}


### PR DESCRIPTION
# Overview

New Feature

**Summary:** Added helper class to determine whether a user can make a specific type of request. Only users with the `STUDENT` role should be able to make `/projects` requests, and only users with the `FACULTY` role should be able to make `/students` requests.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

New class `UserRequestValidator` added, which contains the `canMakeRequest(String email, String requestType)` method that determines if the user with the given email is allowed to perform the given request.

## End-to-End Testing Instructions

1) Make sure that there is at least 1 valid user with role `STUDENT` in the database, and at least 1 valid user with the role `FACULTY`.
2) Write a helper class to call the `canMakeRequest` and test that the the request types "projects" and "students" can only be made by their appropriate user roles