### PR TITLE
Integrate backend userservice with security/authentication

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
@@ -8,6 +8,8 @@
 
 package COMP_49X_our_search.backend.authentication;
 
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.services.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,9 +22,11 @@ import java.util.Map;
 public class AuthController {
 
     private final OAuthChecker OAuthChecker;
+    private final UserService userService;
 
-    public AuthController(OAuthChecker OAuthChecker) {
+    public AuthController(OAuthChecker OAuthChecker, UserService userService) {
         this.OAuthChecker = OAuthChecker;
+        this.userService = userService;
     }
 
     @GetMapping("/check-auth")
@@ -35,12 +39,16 @@ public class AuthController {
             response.put("isAuthenticated", "true");
 
             String email = OAuthChecker.getAuthUserEmail(authentication);
-            System.out.println("email: " + email);
+            if (userService.userExists(email)) {
+                UserRole role = userService.getUserRoleByEmail(email);
+                if (role == UserRole.STUDENT) {
+                    response.put("isStudent", "true");
+                } else if (role == UserRole.FACULTY) {
+                    response.put("isFaculty", "true");
+                }
+            }
 
-            // TODO check db if they already exist based on the email. returning a default value for now
-            response.put("isStudent", "true");
-//            response.put("isFaculty", "true");
-//            response.put("isAdmin", "true");
+            // TODO in later sprint: response.put("isAdmin", "true");
         }
 
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Department.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Department.java
@@ -6,7 +6,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.HashSet;
 import java.util.Set;

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Discipline.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Discipline.java
@@ -5,11 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Major.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Major.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.HashSet;

--- a/backend/src/main/java/COMP_49X_our_search/backend/fetcher/FetcherModuleController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/fetcher/FetcherModuleController.java
@@ -7,7 +7,6 @@ import proto.core.Core.ModuleConfig;
 import proto.core.Core.ModuleResponse;
 import proto.fetcher.FetcherModule.DirectType;
 import proto.fetcher.FetcherModule.FetcherRequest;
-import proto.fetcher.FetcherModule.FetcherRequest.FetcherTypeCase;
 import proto.fetcher.FetcherModule.FetcherResponse;
 import proto.fetcher.FetcherModule.FilteredType;
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -1,10 +1,6 @@
 package COMP_49X_our_search.backend.gateway;
 
-import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoDisciplineWithMajorsToDto;
-
-import COMP_49X_our_search.backend.gateway.dto.DepartmentDTO;
 import COMP_49X_our_search.backend.gateway.dto.DisciplineDTO;
-import COMP_49X_our_search.backend.gateway.dto.ProjectHierarchyDTO;
 import COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import proto.core.Core.ModuleConfig;
 import proto.core.Core.ModuleResponse;
-import proto.fetcher.FetcherModule.DirectFetcher;
-import proto.fetcher.FetcherModule.DirectType;
 import proto.fetcher.FetcherModule.FetcherRequest;
 import proto.fetcher.FetcherModule.FilteredFetcher;
 import proto.fetcher.FetcherModule.FilteredType;

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/ProjectHierarchyDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/ProjectHierarchyDTO.java
@@ -1,6 +1,5 @@
 package COMP_49X_our_search.backend.gateway.dto;
 
-import COMP_49X_our_search.backend.database.entities.Discipline;
 import java.util.List;
 
 // TODO(@acescudero): Unused, will leave in case we need to adjust the /projects

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
@@ -1,6 +1,5 @@
 package COMP_49X_our_search.backend.gateway.util;
 
-import COMP_49X_our_search.backend.gateway.dto.DepartmentDTO;
 import COMP_49X_our_search.backend.gateway.dto.DisciplineDTO;
 import COMP_49X_our_search.backend.gateway.dto.FacultyDTO;
 import COMP_49X_our_search.backend.gateway.dto.MajorDTO;

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerIntegrationTest.java
@@ -12,7 +12,6 @@ import COMP_49X_our_search.backend.database.enums.UserRole;
 import COMP_49X_our_search.backend.database.services.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -38,11 +37,15 @@ class AuthControllerIntegrationTest {
 
     @MockBean
     private OAuthChecker mockOAuthChecker;
-    @Mock
+    @MockBean
     private UserService mockUserService;
+
+    private String email;
 
     @BeforeEach
     void setUp() {
+        email = "test@sandiego.edu";
+
         Map<String, String> responseBeforeModification = new HashMap<>();
         responseBeforeModification.put("isAuthenticated", "false");
         responseBeforeModification.put("isStudent", "false");
@@ -66,7 +69,6 @@ class AuthControllerIntegrationTest {
 
     @Test
     void testCheckAuthStatus_AuthenticatedStudent() throws Exception {
-        String email = "test@sandiego.edu";
         when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(true);
         when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn(email);
         when(mockUserService.userExists(email)).thenReturn(true);
@@ -81,26 +83,18 @@ class AuthControllerIntegrationTest {
     @Test
     void testCheckAuthStatus_AuthenticatedFaculty() throws Exception {
         when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(true);
-        when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn("test@sandiego.edu");
-        when(mockUserService.userExists(Mockito.any())).thenReturn(true);
-        when(mockUserService.getUserRoleByEmail(Mockito.any())).thenReturn(UserRole.FACULTY);
+        when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn(email);
+        when(mockUserService.userExists(email)).thenReturn(true);
+        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.FACULTY);
 
         mockMvc.perform(get("/check-auth"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isAuthenticated").value("true"))
-                .andExpect(jsonPath("$.isAdmin").value("true"));
+                .andExpect(jsonPath("$.isFaculty").value("true"));
     }
 
     // TODO the below tests will be executed once the method to check the DB for user role is completed
 //    @Test
 //    void testCheckAuthStatus_AuthenticatedAdmin() throws Exception {
-//        when(mockOAuthChecker.isAuthenticated(Mockito.any())).thenReturn(true);
-//        when(mockOAuthChecker.getAuthUserEmail(Mockito.any())).thenReturn("test@sandiego.edu");
-//        //when(...get user role...).thenReturn(...faculty...); //TODO method
-//
-//        mockMvc.perform(get("/check-auth"))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.isAuthenticated").value("true"))
-//                .andExpect(jsonPath("$.isAdmin").value("true"));
 //    }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
@@ -132,15 +132,15 @@ class AuthControllerTest {
         assertEquals(expectedResponse, response.getBody());
     }
 
-    @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
-    @Test
-    void testCheckAuthStatus_AuthenticatedAdmin() {
-        Map<String, String> expectedResponse = Map.of(
-                "isAuthenticated", "true",
-                "isStudent", "false",
-                "isFaculty", "false",
-                "isAdmin", "true"
-        );
+    // @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
+    // @Test
+    // void testCheckAuthStatus_AuthenticatedAdmin() {
+        // Map<String, String> expectedResponse = Map.of(
+        //         "isAuthenticated", "true",
+        //         "isStudent", "false",
+        //         "isFaculty", "false",
+        //         "isAdmin", "true"
+        // );
 
         // TODO once method to get user role from DB is implemented
 //        Authentication mockAuth = mock(Authentication.class);
@@ -153,5 +153,5 @@ class AuthControllerTest {
 //        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
 //        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
 //        assertEquals(expectedResponse, response.getBody());
-    }
+    // }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
@@ -7,6 +7,8 @@
 
 package COMP_49X_our_search.backend.authentication;
 
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.services.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -28,10 +30,13 @@ class AuthControllerTest {
     @Mock
     private OAuthChecker mockOAuthChecker;
 
+    @Mock
+    private UserService mockUserService;
+
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        authController = new AuthController(mockOAuthChecker);
+        authController = new AuthController(mockOAuthChecker, mockUserService);
     }
 
     @Test
@@ -62,16 +67,19 @@ class AuthControllerTest {
                 "isAdmin", "false"
         );
 
+        String email = "test@sandiego.edu";
         Authentication mockAuth = mock(Authentication.class);
         when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
         when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
-        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn("test@student.example.com");
+        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+        when(mockUserService.userExists(email)).thenReturn(true);
+        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.STUDENT);
 
         ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
         assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
         assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-        assertEquals(expectedResponse.get("isStudent"), response.getBody().get("isStudent"));
+        assertEquals(expectedResponse, response.getBody());
     }
 
     @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
@@ -84,17 +92,44 @@ class AuthControllerTest {
                 "isAdmin", "false"
         );
 
-        // TODO once method to get user role from DB is implemented
-//        Authentication mockAuth = mock(Authentication.class);
-//        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
-//        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
-//        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn("test@faculty.example.com");
-//
-//        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
-//
-//        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-//        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-//        assertEquals(expectedResponse.get("isFaculty"), response.getBody().get("isFaculty"));
+        String email = "professor@sandiego.edu";
+        Authentication mockAuth = mock(Authentication.class);
+        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+        when(mockUserService.userExists(email)).thenReturn(true);
+        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.FACULTY);
+
+        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+        assertEquals(expectedResponse, response.getBody());
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    void testCheckAuthStatus_AuthenticatedNoRole() {
+        Map<String, String> expectedResponse = Map.of(
+                "isAuthenticated", "true",
+                "isStudent", "false",
+                "isFaculty", "false",
+                "isAdmin", "false"
+        );
+
+        String email = "test@sandiego.edu";
+        Authentication mockAuth = mock(Authentication.class);
+        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+        when(mockUserService.userExists(email)).thenReturn(false);
+        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.STUDENT);
+
+        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+
+        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+        assertEquals(expectedResponse, response.getBody());
     }
 
     @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
@@ -117,6 +152,6 @@ class AuthControllerTest {
 //
 //        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
 //        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-//        assertEquals(expectedResponse.get("isAdmin"), response.getBody().get("isAdmin"));
+//        assertEquals(expectedResponse, response.getBody());
     }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/MajorServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/MajorServiceTest.java
@@ -3,7 +3,6 @@ package COMP_49X_our_search.backend.database;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.repositories.MajorRepository;

--- a/backend/src/test/java/COMP_49X_our_search/backend/fetcher/ProjectFetcherTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/fetcher/ProjectFetcherTest.java
@@ -8,13 +8,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import COMP_49X_our_search.backend.database.entities.Discipline;
-import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Faculty;
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.entities.Project;
 import COMP_49X_our_search.backend.database.entities.ResearchPeriod;
 import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
-import COMP_49X_our_search.backend.database.services.DisciplineService;
 import COMP_49X_our_search.backend.database.services.DisciplineService;
 import COMP_49X_our_search.backend.database.services.MajorService;
 import COMP_49X_our_search.backend.database.services.ProjectService;

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,5 +1,5 @@
 # H2 In-Memory Database Configuration for Tests
-spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;IGNORECASE=TRUE;DATABASE_TO_UPPER=FALSE  
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL;IGNORECASE=TRUE;DATABASE_TO_UPPER=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,5 +46,14 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "babel-jest": "^29.7.0",
     "jest": "^27.5.1"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!src/**/*.d.ts",
+      "!src/index.js",
+      "!src/reportWebVitals.js",
+      "!src/utils/*"
+    ]
   }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Other

**Summary:** The backend endpoint to check if the user is authenticated or not no longer has hardcoded data to return. Now, it uses the userservice to check if the user has a profile or not and what their role is before sending a response. The oauthsuccessHandler also uses the userservice to determine what frontend url to redirect to after logging in. If they already have a profile, they are redirected to /posts, but if they are not, they are redirected to /ask-for-role.
I also fixed some linting errors by removing unused imports on all backend files.

### Object-Oriented Models
Made use of the UserService class.

## End-to-End Testing Instructions
1. hit login
2. login
3. you will be redirect to /ask-for-role because you dont have a profile yet! (create profile is not yet integrated)
