### PR TITLE
Logout of google entirely

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/security/EmailValidator.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/EmailValidator.java
@@ -1,3 +1,11 @@
+/**
+ * This class validates emails based on specific requirements for the application's authentication.
+ * The isValidEmail method specifically targets validating a given email based on its domain.
+ * This is so the app can only allow users with certain domains to authenticate.
+ *
+ * @author Natalie Jungquist
+ */
+
 package COMP_49X_our_search.backend.security;
 
 import org.springframework.stereotype.Component;

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/OAuthSuccessHandler.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/OAuthSuccessHandler.java
@@ -24,14 +24,10 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+import static COMP_49X_our_search.backend.security.SecurityConstants.*;
+
 @Component
 public class OAuthSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
-
-    private static final String frontendUrl = "http://localhost:3000"; // TODO hardcoded for now
-    private static final String ALLOWED_DOMAIN = "@sandiego.edu";
-    private static final String invalidEmailPath = "/invalid-email";
-    private static final String noProfilePath = "/ask-for-role";
-    private static final String hasProfilePath = "/posts";
 
     private final EmailValidator emailValidator;
     private final UserService userService;
@@ -64,13 +60,13 @@ public class OAuthSuccessHandler extends SavedRequestAwareAuthenticationSuccessH
         // check if the user has a profile already or not. This condition determines what frontend url to go to.
         String redirectPath;
         if (userService.userExists(email)) {
-            redirectPath = hasProfilePath;
+            redirectPath = HAS_PROFILE_PATH;
         } else {
-            redirectPath = noProfilePath;
+            redirectPath = NO_PROFILE_PATH;
         }
 
         this.setAlwaysUseDefaultTargetUrl(true);
-        this.setDefaultTargetUrl(frontendUrl + redirectPath);
+        this.setDefaultTargetUrl(FRONTEND_URL + redirectPath);
         super.onAuthenticationSuccess(request, response, authentication);
     }
 
@@ -83,6 +79,6 @@ public class OAuthSuccessHandler extends SavedRequestAwareAuthenticationSuccessH
         request.getSession().invalidate();
         new CookieClearingLogoutHandler(AbstractRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY).logout(request, response, authentication);
 
-        response.sendRedirect(frontendUrl + invalidEmailPath);
+        response.sendRedirect(FRONTEND_URL + INVALID_EMAIL_PATH);
     }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/SecurityConfig.java
@@ -25,12 +25,13 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
+import static COMP_49X_our_search.backend.security.SecurityConstants.FRONTEND_URL;
+import static COMP_49X_our_search.backend.security.SecurityConstants.GOOGLE_LOGOUT_URL;
+
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
-
-    private static final String frontendUrl = "http://localhost:3000";
 
     private final OAuthSuccessHandler oAuthSuccessHandler;
 
@@ -62,8 +63,8 @@ public class SecurityConfig {
                 )
                 .logout(logout ->
                         logout
-                                .logoutUrl("/logout") // Backend logout endpoint
-                                .logoutSuccessUrl(frontendUrl + "/logout")
+                                .logoutUrl("/logout") // Spring Security's default backend logout endpoint
+                                .logoutSuccessUrl(GOOGLE_LOGOUT_URL)
                                 .invalidateHttpSession(true)
                                 .clearAuthentication(true)
                                 .deleteCookies("JSESSIONID") // Clear cookie that stores authentication status
@@ -82,7 +83,7 @@ public class SecurityConfig {
         // Configures this server so it can only receive requests coming from the frontendUrl.
         // This only affects cross-origin requests made via JavaScript.
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(frontendUrl));
+        config.setAllowedOrigins(List.of(FRONTEND_URL));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowCredentials(true);

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/SecurityConstants.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/SecurityConstants.java
@@ -1,0 +1,23 @@
+/**
+ * This class defines constants that are shared between the classes in the security package,
+ * as well as their respective test cases.
+ * //
+ * All routes and URLs used in the security configuration and authentication flows
+ * are centralized here to ensure consistency and accessibility across both the
+ * application source code and test cases.
+ *
+ * @author Natalie Jungquist
+ */
+
+package COMP_49X_our_search.backend.security;
+
+public class SecurityConstants {
+
+    static final String FRONTEND_URL = "http://localhost:3000";
+    static final String ALLOWED_DOMAIN = "@sandiego.edu";
+    static final String INVALID_EMAIL_PATH = "/invalid-email";
+    static final String NO_PROFILE_PATH = "/ask-for-role";
+    static final String HAS_PROFILE_PATH = "/posts";
+    static final String GOOGLE_LOGOUT_URL = "https://accounts.google.com/logout";
+    static final String OAUTH_REDIRECT_ENDPOINT = "/login/oauth2/code/google"; // this is created by spring security/google
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,16 +1,6 @@
 spring.application.name=backend
 
-# Base URLs
-backend-url=http://localhost:8080
-frontend-url=http://localhost:3000
-
-# Backend endpoints
-oauth-redirect-endpoint=/login/oauth2/code/google
 # login=/oauth2/authorization/google
-
-# Frontend paths
-hasProfilePath=/posts
-noProfilePath=/ask-for-role
 
 # Secrets file stores sensitive information
 spring.config.import=optional:secrets.properties

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessHandlerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessHandlerTest.java
@@ -24,12 +24,11 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.io.IOException;
 
+import static COMP_49X_our_search.backend.security.SecurityConstants.FRONTEND_URL;
+import static COMP_49X_our_search.backend.security.SecurityConstants.INVALID_EMAIL_PATH;
 import static org.mockito.Mockito.*;
 
 public class OAuthSuccessHandlerTest {
-
-    private static final String frontendUrl = "http://localhost:3000";
-    private static final String invalidEmailPath = "/invalid-email";
 
     private OAuthSuccessHandler OAuthSuccessHandler;
 
@@ -94,6 +93,6 @@ public class OAuthSuccessHandlerTest {
         OAuthSuccessHandler.onAuthenticationSuccess(request, response, authentication);
 
         verify(session).invalidate(); //Session ends to ensure the user does not get logged in
-        verify(response).sendRedirect(frontendUrl + invalidEmailPath);
+        verify(response).sendRedirect(FRONTEND_URL + INVALID_EMAIL_PATH);
     }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/OAuthSuccessIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static COMP_49X_our_search.backend.security.SecurityConstants.OAUTH_REDIRECT_ENDPOINT;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -40,7 +41,7 @@ public class OAuthSuccessIntegrationTest {
         // This test simulates a successful OAuth2 login and verifies that after authentication,
         // the user is redirected to the expected frontend URL. Since Spring Security handles
         // the actual OAuth2 callback, we use oauth2Login() to mock a successful authentication.
-        mockMvc.perform(get("/login/oauth2/code/google")
+        mockMvc.perform(get(OAUTH_REDIRECT_ENDPOINT)
                         .param("state", "some-state")
                         .param("code", "some-auth-code")
                         .param("scope", "email profile openid")

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityConfigTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityConfigTest.java
@@ -19,14 +19,13 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Map;
 
+import static COMP_49X_our_search.backend.security.SecurityConstants.FRONTEND_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SecurityConfigTest {
 
     @Mock
     private OAuthSuccessHandler oAuthSuccessHandler;
-
-    private static final String frontendUrl = "http://localhost:3000";
 
     @Test
     void testSecurityConfig_CorsConfigNotNull() throws Exception {
@@ -56,7 +55,7 @@ public class SecurityConfigTest {
         Map.Entry<String, CorsConfiguration> registeredConfig = allConfigs.entrySet().iterator().next();
         CorsConfiguration config = registeredConfig.getValue();
 
-        assertThat(config.getAllowedOrigins()).contains(frontendUrl);
+        assertThat(config.getAllowedOrigins()).contains(FRONTEND_URL);
         assertThat(config.getAllowedMethods()).contains("GET", "POST", "PUT", "DELETE", "OPTIONS");
         assertThat(config.getAllowCredentials()).isTrue();
         assertThat(config.getAllowedHeaders()).contains("*");

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityIntegrationTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/SecurityIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static COMP_49X_our_search.backend.security.SecurityConstants.GOOGLE_LOGOUT_URL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -33,8 +34,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 public class SecurityIntegrationTest {
-
-    private final static String frontendUrl = "http://localhost:3000";
 
     @Autowired
     private MockMvc mockMvc;
@@ -93,6 +92,6 @@ public class SecurityIntegrationTest {
     void testLogoutInvalidatesSession() throws Exception {
         mockMvc.perform(post("/logout"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl(frontendUrl + "/logout"));
+                .andExpect(redirectedUrl(GOOGLE_LOGOUT_URL));
     }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature/Bug Fix

**Summary:** 
Changed the logout mechanism to log the user out of their google accounts instead of just the application. This fixes a bug that has to do with OAuth2. Before the user could log out of our application, but Google would cache the previous login information, and bypass subsequent logins, no matter if they tried putting in a new email address. This would be a problem if multiple users with different USD emails logged in and out one after another. Google would cache the first login, preventing the second person from logging in as themselves. You would have to manually go to google.com and sign out. Now, logging out of the app signs you out of Google, removing that extra manual sign out step. 

## UI/UX Implementation
n/a

## Model Updates
n/a

### Data Models
n/a

### Object-Oriented Models
n/a

## End-to-End Testing Instructions
1. login on the app from the frontend url
2. then go to http://localhost:8080/logout and you will be logged out of mycas and google