### PR TITLE
Get umbrella topics

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/UmbrellaTopic.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/UmbrellaTopic.java
@@ -39,6 +39,11 @@ public class UmbrellaTopic {
     this.projects = projects != null ? projects : new HashSet<>();
   }
 
+  public UmbrellaTopic(int id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
   public Integer getId() {
     return id;
   }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UmbrellaTopicService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UmbrellaTopicService.java
@@ -1,0 +1,34 @@
+/**
+ * Service class for managing UmbrellaTopic entities. This class provides business
+ * logic for retrieving department data from the database through the
+ * UmbrellaTopicRepository.
+ *
+ * This service is annotated with @Service to indicate that it's managed by
+ * Spring.
+ *
+ * @author Natalie Jungquist
+ */
+package COMP_49X_our_search.backend.database.services;
+
+import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
+import COMP_49X_our_search.backend.database.repositories.UmbrellaTopicRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UmbrellaTopicService {
+
+    private final UmbrellaTopicRepository umbrellaTopicRepository;
+
+    @Autowired
+    public UmbrellaTopicService(UmbrellaTopicRepository repository) {
+        this.umbrellaTopicRepository = repository;
+    }
+
+    public List<UmbrellaTopic> getAllUmbrellaTopics() {
+        return umbrellaTopicRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
+    }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -21,6 +21,7 @@ import COMP_49X_our_search.backend.authentication.OAuthChecker;
 import COMP_49X_our_search.backend.database.services.DepartmentService;
 import COMP_49X_our_search.backend.database.services.MajorService;
 import COMP_49X_our_search.backend.database.services.ResearchPeriodService;
+import COMP_49X_our_search.backend.database.services.UmbrellaTopicService;
 import COMP_49X_our_search.backend.gateway.dto.*;
 import COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter;
 
@@ -60,14 +61,16 @@ public class GatewayController {
   private final DepartmentService departmentService;
   private final MajorService majorService;
   private final ResearchPeriodService researchPeriodService;
+  private final UmbrellaTopicService umbrellaTopicService;
 
   @Autowired
-  public GatewayController(ModuleInvoker moduleInvoker, OAuthChecker oAuthChecker, DepartmentService departmentService, MajorService majorService, ResearchPeriodService researchPeriodService) {
+  public GatewayController(ModuleInvoker moduleInvoker, OAuthChecker oAuthChecker, DepartmentService departmentService, MajorService majorService, ResearchPeriodService researchPeriodService, UmbrellaTopicService umbrellaTopicService) {
     this.moduleInvoker = moduleInvoker;
     this.oAuthChecker = oAuthChecker;
     this.departmentService = departmentService;
     this.majorService = majorService;
     this.researchPeriodService = researchPeriodService;
+    this.umbrellaTopicService = umbrellaTopicService;
   }
 
   @GetMapping("/projects")
@@ -262,6 +265,20 @@ public class GatewayController {
               .map(researchPeriod -> new ResearchPeriodDTO(researchPeriod.getId(), researchPeriod.getName()))
               .toList();
       return ResponseEntity.ok(researchPeriodDTOS);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());
+    }
+  }
+
+  @GetMapping("/umbrella-topics")
+  public ResponseEntity<List<UmbrellaTopicDTO>> getUmbrellaTopics() {
+    try {
+      List<UmbrellaTopicDTO> umbrellaTopicDTOs = umbrellaTopicService.getAllUmbrellaTopics()
+              .stream()
+              .map(ut -> new UmbrellaTopicDTO(ut.getId(), ut.getName()))
+              .toList();
+      return ResponseEntity.ok(umbrellaTopicDTOs);
     } catch (Exception e) {
       e.printStackTrace();
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/UmbrellaTopicDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/UmbrellaTopicDTO.java
@@ -1,0 +1,30 @@
+package COMP_49X_our_search.backend.gateway.dto;
+
+public class UmbrellaTopicDTO {
+
+    private int id;
+    private String name;
+
+    public UmbrellaTopicDTO() {}
+
+    public UmbrellaTopicDTO(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/UmbrellaTopicServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/UmbrellaTopicServiceTest.java
@@ -1,0 +1,42 @@
+package COMP_49X_our_search.backend.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
+import COMP_49X_our_search.backend.database.repositories.UmbrellaTopicRepository;
+import COMP_49X_our_search.backend.database.services.UmbrellaTopicService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+@SpringBootTest(classes = {UmbrellaTopicService.class})
+@ActiveProfiles("test")
+public class UmbrellaTopicServiceTest {
+
+    @Autowired
+    private UmbrellaTopicService service;
+
+    @MockBean
+    private UmbrellaTopicRepository umbrellaTopicRepository;
+
+    @Test
+    void testGetAllUmbrellaTopics() {
+        UmbrellaTopic topic1 = new UmbrellaTopic(1, "race");
+        UmbrellaTopic topic2 = new UmbrellaTopic(2, "intersectionality");
+
+        Mockito.when(umbrellaTopicRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
+                .thenReturn(List.of(topic1, topic2));
+
+        List<UmbrellaTopic> topics = service.getAllUmbrellaTopics();
+
+        assertEquals(2, topics.size());
+        assertTrue(topics.containsAll(List.of(topic1, topic2)));
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -10,9 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.entities.ResearchPeriod;
+import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
 import COMP_49X_our_search.backend.database.services.DepartmentService;
 import COMP_49X_our_search.backend.database.services.MajorService;
 import COMP_49X_our_search.backend.database.services.ResearchPeriodService;
+import COMP_49X_our_search.backend.database.services.UmbrellaTopicService;
 import COMP_49X_our_search.backend.gateway.dto.CreateFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.CreateStudentRequestDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -67,6 +69,8 @@ public class GatewayControllerTest {
     private DepartmentService departmentService;
     @MockBean
     private MajorService majorService;
+    @MockBean
+    private UmbrellaTopicService umbrellaTopicService;
 
     @BeforeEach
     void setUp() {
@@ -381,5 +385,22 @@ public class GatewayControllerTest {
                 .andExpect(jsonPath("$[1].id").value(major2.getId()))
                 .andExpect(jsonPath("$[0].name").value(major1.getName()))
                 .andExpect(jsonPath("$[1].name").value(major2.getName()));
+    }
+
+    @Test
+    @WithMockUser
+    void getUmbrellaTopics_returnsExpectedSuccess() throws Exception {
+        UmbrellaTopic topic1 = new UmbrellaTopic(1, "race");
+        UmbrellaTopic topic2 = new UmbrellaTopic(2, "intersectionality");
+        List<UmbrellaTopic> topics = List.of(topic1, topic2);
+        when(umbrellaTopicService.getAllUmbrellaTopics()).thenReturn(topics);
+
+        mockMvc.perform(get("/umbrella-topics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(topic1.getId()))
+                .andExpect(jsonPath("$[1].id").value(topic2.getId()))
+                .andExpect(jsonPath("$[0].name").value(topic1.getName()))
+                .andExpect(jsonPath("$[1].name").value(topic2.getName()));
     }
 }


### PR DESCRIPTION
# Overview

**Type of Change:**  New Feature

**Summary:** backend endpoint to return list of umbrella topics from the database at /umbrella-topics GET

## UI/UX Implementation
No changes

## Model Updates
Created UmbrellaTopicDTO with id and name

### Data Models
No changes

### Object-Oriented Models
Created UmbrellaTopicService getAllUmbrellaTopics method
Updated GatewayController to use this service

## End-to-End Testing Instructions
1. login
2. go to backendurl/umbrella-topics 