### PR TITLE
Faculty profile sees projects

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -27,10 +27,10 @@ import RequireFacultyProfile from './components/Auth/RequireFacultyProfile.js'
 import FacultyProfileView from './components/FacultyProfileView.js'
 
 function App () {
-  const [isAuthenticated, setisAuthenticated] = useState(false)
+  const [isAuthenticated, setisAuthenticated] = useState(true)
   const [isStudent, setIsStudent] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
-  const [isFaculty, setIsFaculty] = useState(false)
+  const [isFaculty, setIsFaculty] = useState(true)
   const [error505, setError505] = useState(false)
   const [loading, setLoading] = useState(true) // Loading state is required to ensure that nothing loads until the call to the backend has returned a response.
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -205,7 +205,7 @@ function App () {
       />
 
       <Route
-        path='/edit-professor-profile' element={
+        path='/view-professor-profile' element={
           <RequireFacultyProfile
             isAuthenticated={isAuthenticated}
             isStudent={isStudent} isFaculty={isFaculty} isAdmin={isAdmin}

--- a/frontend/src/__tests__/FacultyProfileView.test.js
+++ b/frontend/src/__tests__/FacultyProfileView.test.js
@@ -52,6 +52,16 @@ describe('FacultyProfileView', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/posts')
   })
 
+  it('navigates to /create-project page when create button is clicked', async () => {
+    renderWithTheme(<FacultyProfileView />)
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+    const button = screen.getByRole('button', { name: /create new project/i })
+    fireEvent.click(button)
+
+    expect(mockNavigate).toHaveBeenCalledWith('/create-project')
+  })
+
   it('displays a custom error message when fetching profile fails', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,

--- a/frontend/src/__tests__/FacultyProfileView.test.js
+++ b/frontend/src/__tests__/FacultyProfileView.test.js
@@ -93,17 +93,12 @@ describe('FacultyProfileView', () => {
     expect(screen.getByRole('button', { name: /Edit Profile/i })).toBeInTheDocument()
 
     // Check the existence of projects post list
-    expect(screen.getByAltText(/Post A/i)).toBeInTheDocument()
-    expect(screen.getByAltText(/Post B/i)).toBeInTheDocument()
-    expect(screen.getByAltText(/Post C/i)).toBeInTheDocument()
+    expect(screen.getByText(/Post A/i)).toBeInTheDocument()
+    expect(screen.getByText(/Post B/i)).toBeInTheDocument()
+    expect(screen.getByText(/Chemistry/i)).toBeInTheDocument()
   })
 
-  it('displays "No profile found." when profile is null', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => null
-    })
-
+  it('displays "No profile found." when profile is empty', async () => {
     renderWithTheme(<FacultyProfileView />)
     await waitFor(() => {
       expect(screen.getByText(/No profile found\./i)).toBeInTheDocument()

--- a/frontend/src/__tests__/FacultyProfileView.test.js
+++ b/frontend/src/__tests__/FacultyProfileView.test.js
@@ -3,6 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import FacultyProfileView from '../components/FacultyProfileView'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { mockThreeActiveProjects } from '../resources/mockData'
 
 // Need to wrap the component in this because it uses navigate from react-router-dom
 const renderWithTheme = (ui) => {
@@ -69,7 +70,8 @@ describe('FacultyProfileView', () => {
     const dummyProfile = {
       name: 'Dr. John Doe',
       email: 'john.doe@example.com',
-      department: ['Computer Science', 'Mathematics']
+      department: ['Computer Science', 'Mathematics'],
+      projects: mockThreeActiveProjects
     }
 
     global.fetch = jest.fn().mockResolvedValue({
@@ -89,6 +91,11 @@ describe('FacultyProfileView', () => {
     // Check the existence of Back and Edit Profile buttons
     expect(screen.getByRole('button', { name: /Back/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Edit Profile/i })).toBeInTheDocument()
+
+    // Check the existence of projects post list
+    expect(screen.getByAltText(/Post A/i)).toBeInTheDocument()
+    expect(screen.getByAltText(/Post B/i)).toBeInTheDocument()
+    expect(screen.getByAltText(/Post C/i)).toBeInTheDocument()
   })
 
   it('displays "No profile found." when profile is null', async () => {

--- a/frontend/src/components/FacultyProfileView.js
+++ b/frontend/src/components/FacultyProfileView.js
@@ -10,14 +10,19 @@ import React, { useState, useEffect } from 'react'
 import { Box, Button, Typography, Paper, CircularProgress } from '@mui/material'
 import { backendUrl } from '../resources/constants'
 import { useNavigate } from 'react-router-dom'
+import { viewProjectsFlag } from '../resources/constants'
+import PostList from './PostList'
+import PostDialog from './PostDialog'
 
 export const emptyProfile = {
   name: '',
   email: '',
-  department: []
+  department: [],
+  projects: []
 }
 
 const FacultyProfileView = () => {
+  const [selectedPost, setSelectedPost] = useState(null)
   const navigate = useNavigate()
   const [profile, setProfile] = useState(emptyProfile)
   const [loading, setLoading] = useState(true)
@@ -81,6 +86,26 @@ const FacultyProfileView = () => {
         : (
           <Typography variant='body1'>No profile found.</Typography>
           )}
+
+<Typography variant='h6'>
+              <strong>My Projects</strong>
+            </Typography>
+      <PostList
+                  postings={profile.projects}
+                  setSelectedPost={setSelectedPost}
+                  isStudent={false}
+                  isFaculty={true}
+                  isAdmin={false}
+                  facultyView={viewProjectsFlag}
+                />
+                <PostDialog
+                  post={selectedPost}
+                  onClose={() => setSelectedPost(null)}
+                  isStudent={false}
+                  isFaculty={true}
+                  isAdmin={false}
+                  facultyView={viewProjectsFlag}
+                />
       <Button variant='contained' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/edit-professor-profile') }}>
         Edit Profile
       </Button>

--- a/frontend/src/components/FacultyProfileView.js
+++ b/frontend/src/components/FacultyProfileView.js
@@ -116,6 +116,9 @@ const FacultyProfileView = () => {
             />
           </>
           )}
+      <Button variant='outlined' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/create-project') }}>
+        Create new project
+      </Button>
       <Button variant='contained' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/edit-professor-profile') }}>
         Edit Profile
       </Button>

--- a/frontend/src/components/FacultyProfileView.js
+++ b/frontend/src/components/FacultyProfileView.js
@@ -89,31 +89,33 @@ const FacultyProfileView = () => {
       <Typography variant='h6'>
         My Projects
       </Typography>
-      {profile.projects.length === 0 ? (
-        <Typography variant='body1'>
-          No projects yet
-        </Typography>
-      ) : (
-        <>
-        <PostList
-        postings={profile.projects}
-        setSelectedPost={setSelectedPost}
-        isStudent={false}
-        isFaculty
-        isAdmin={false}
-        facultyView={viewProjectsFlag}
-        isOnFacultyProfile={true}
-      />
-      <PostDialog
-        post={selectedPost}
-        onClose={() => setSelectedPost(null)}
-        isStudent={false}
-        isFaculty
-        isAdmin={false}
-        facultyView={viewProjectsFlag}
-      />
-        </>
-      )}
+      {profile.projects.length === 0
+        ? (
+          <Typography variant='body1'>
+            No projects yet
+          </Typography>
+          )
+        : (
+          <>
+            <PostList
+              postings={profile.projects}
+              setSelectedPost={setSelectedPost}
+              isStudent={false}
+              isFaculty
+              isAdmin={false}
+              facultyView={viewProjectsFlag}
+              isOnFacultyProfile
+            />
+            <PostDialog
+              post={selectedPost}
+              onClose={() => setSelectedPost(null)}
+              isStudent={false}
+              isFaculty
+              isAdmin={false}
+              facultyView={viewProjectsFlag}
+            />
+          </>
+          )}
       <Button variant='contained' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/edit-professor-profile') }}>
         Edit Profile
       </Button>

--- a/frontend/src/components/FacultyProfileView.js
+++ b/frontend/src/components/FacultyProfileView.js
@@ -8,9 +8,8 @@
 
 import React, { useState, useEffect } from 'react'
 import { Box, Button, Typography, Paper, CircularProgress } from '@mui/material'
-import { backendUrl } from '../resources/constants'
+import { backendUrl, viewProjectsFlag } from '../resources/constants'
 import { useNavigate } from 'react-router-dom'
-import { viewProjectsFlag } from '../resources/constants'
 import PostList from './PostList'
 import PostDialog from './PostDialog'
 
@@ -73,7 +72,7 @@ const FacultyProfileView = () => {
           {error}
         </Typography>
       )}
-      {profile
+      {profile.name !== ''
         ? (
           <Box>
             <Typography variant='body1'><strong>Name:</strong> {profile.name}</Typography>
@@ -87,25 +86,34 @@ const FacultyProfileView = () => {
           <Typography variant='body1'>No profile found.</Typography>
           )}
 
-<Typography variant='h6'>
-              <strong>My Projects</strong>
-            </Typography>
-      <PostList
-                  postings={profile.projects}
-                  setSelectedPost={setSelectedPost}
-                  isStudent={false}
-                  isFaculty={true}
-                  isAdmin={false}
-                  facultyView={viewProjectsFlag}
-                />
-                <PostDialog
-                  post={selectedPost}
-                  onClose={() => setSelectedPost(null)}
-                  isStudent={false}
-                  isFaculty={true}
-                  isAdmin={false}
-                  facultyView={viewProjectsFlag}
-                />
+      <Typography variant='h6'>
+        My Projects
+      </Typography>
+      {profile.projects.length === 0 ? (
+        <Typography variant='body1'>
+          No projects yet
+        </Typography>
+      ) : (
+        <>
+        <PostList
+        postings={profile.projects}
+        setSelectedPost={setSelectedPost}
+        isStudent={false}
+        isFaculty
+        isAdmin={false}
+        facultyView={viewProjectsFlag}
+        isOnFacultyProfile={true}
+      />
+      <PostDialog
+        post={selectedPost}
+        onClose={() => setSelectedPost(null)}
+        isStudent={false}
+        isFaculty
+        isAdmin={false}
+        facultyView={viewProjectsFlag}
+      />
+        </>
+      )}
       <Button variant='contained' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/edit-professor-profile') }}>
         Edit Profile
       </Button>

--- a/frontend/src/components/PostList.js
+++ b/frontend/src/components/PostList.js
@@ -72,7 +72,7 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, f
                   {!isOnFacultyProfile && (
                     <EmailIcon />
                   )}
-          
+
                 </IconButton>
 
                 <Typography variant='h7' fontWeight='bold' component='div' sx={{ mb: 1, pr: 5 }}>

--- a/frontend/src/components/PostList.js
+++ b/frontend/src/components/PostList.js
@@ -20,7 +20,7 @@ import LocalOfferIcon from '@mui/icons-material/LocalOffer'
 import { noPostsMessage, viewProjectsFlag, viewStudentsFlag } from '../resources/constants'
 import PropTypes from 'prop-types'
 
-function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, facultyView }) {
+function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, facultyView, isOnFacultyProfile }) {
   // Filter out inactive postings.
   const activePostings = postings.filter((post) => post.isActive)
 
@@ -69,7 +69,10 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, f
                     color: 'action.active'
                   }}
                 >
-                  <EmailIcon />
+                  {!isOnFacultyProfile && (
+                    <EmailIcon />
+                  )}
+          
                 </IconButton>
 
                 <Typography variant='h7' fontWeight='bold' component='div' sx={{ mb: 1, pr: 5 }}>


### PR DESCRIPTION
# Overview

**Type of Change:** bug fix/new feat

**Summary:** The faculty profile view now shows the projects they are a part of. There is also a button to create new proejct. The form was missing this before. The projects are rendered as a post list like in the /posts page.

## UI/UX Implementation
The view shows the projects now like in our ui prototype. https://www.figma.com/design/wVa9Sz9f2QpHebHeTVb0cI/Sprint-3?node-id=0-1&p=f&t=WX3BSILfGmmpxe1g-0 

## Model Updates
No changes

### Data Models
No changes

### Object-Oriented Models
No changes

## End-to-End Testing Instructions
1. login
2. assuming you have a faculty profile
3. click to view profile/projects
4. see them