### PR TITLE
Implemented update faculty profile endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FacultyRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FacultyRepository.java
@@ -9,8 +9,10 @@
 package COMP_49X_our_search.backend.database.repositories;
 
 import COMP_49X_our_search.backend.database.entities.Faculty;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FacultyRepository extends JpaRepository<Faculty, Integer> {
   boolean existsByEmail(String email);
+  Optional<Faculty> findFacultyByEmail(String email);
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/FacultyService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/FacultyService.java
@@ -1,10 +1,8 @@
 /**
- * Service class for managing Faculty entities. This class provides business
- * logic for retrieving faculty data from the database through the
- * FacultyRepository.
+ * Service class for managing Faculty entities. This class provides business logic for retrieving
+ * faculty data from the database through the FacultyRepository.
  *
- * This service is annotated with @Service to indicate that it's managed by
- * Spring.
+ * <p>This service is annotated with @Service to indicate that it's managed by Spring.
  *
  * @author Augusto Escudero
  */
@@ -31,5 +29,11 @@ public class FacultyService {
 
   public Faculty saveFaculty(Faculty faculty) {
     return facultyRepository.save(faculty);
+  }
+
+  public Faculty getFacultyByEmail(String email) {
+    return facultyRepository
+        .findFacultyByEmail(email)
+        .orElseThrow(() -> new RuntimeException("Faculty not found with email: " + email));
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/EditFacultyRequestDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/EditFacultyRequestDTO.java
@@ -1,0 +1,31 @@
+package COMP_49X_our_search.backend.gateway.dto;
+
+import java.util.List;
+
+public class EditFacultyRequestDTO {
+  private String name;
+  private List<String> department;
+
+  public EditFacultyRequestDTO() {}
+
+  public EditFacultyRequestDTO(String name, List<String> department) {
+    this.name = name;
+    this.department = department;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getDepartment() {
+    return department;
+  }
+
+  public void setDepartment(List<String> department) {
+    this.department = department;
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FacultyDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FacultyDTO.java
@@ -1,9 +1,12 @@
 package COMP_49X_our_search.backend.gateway.dto;
 
+import java.util.List;
+
 public class FacultyDTO {
   private String firstName;
   private String lastName;
   private String email;
+  private List<String> department;
 
   public FacultyDTO() {}
 
@@ -29,5 +32,13 @@ public class FacultyDTO {
 
   public void setEmail(String email) {
     this.email = email;
+  }
+
+  public List<String> getDepartment() {
+    return department;
+  }
+
+  public void setDepartment(List<String> department) {
+    this.department = department;
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
@@ -92,11 +92,12 @@ public final class ProjectHierarchyConverter {
     return dto;
   }
 
-  private static FacultyDTO protoFacultyToFacultyDto(FacultyProto proto) {
+  public static FacultyDTO protoFacultyToFacultyDto(FacultyProto proto) {
     FacultyDTO dto = new FacultyDTO();
     dto.setFirstName(proto.getFirstName());
     dto.setLastName(proto.getLastName());
     dto.setEmail(proto.getEmail());
+    dto.setDepartment(proto.getDepartmentsList());
     return dto;
   }
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
@@ -89,7 +89,7 @@ public class FacultyProfileEditor implements ProfileEditor {
 
   private void validateRequest(EditProfileRequest request) {
     if (!request.hasFacultyProfile()) {
-      throw new IllegalArgumentException("EditProfile must contain 'student_profile'");
+      throw new IllegalArgumentException("EditProfile must contain 'faculty_profile'");
     }
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
@@ -1,0 +1,87 @@
+package COMP_49X_our_search.backend.profile;
+
+import COMP_49X_our_search.backend.database.entities.Department;
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.services.DepartmentService;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.UserService;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import proto.data.Entities.FacultyProto;
+import proto.profile.ProfileModule.EditProfileRequest;
+import proto.profile.ProfileModule.EditProfileResponse;
+
+@Service
+public class FacultyProfileEditor implements ProfileEditor {
+
+  private final FacultyService facultyService;
+  private final DepartmentService departmentService;
+  private final UserService userService;
+
+  @Autowired
+  public FacultyProfileEditor(
+      FacultyService facultyService, DepartmentService departmentService, UserService userService) {
+    this.facultyService = facultyService;
+    this.departmentService = departmentService;
+    this.userService = userService;
+  }
+
+  @Override
+  public EditProfileResponse editProfile(EditProfileRequest request) {
+    validateRequest(request);
+    validateUserRole(request.getUserEmail());
+    try {
+      FacultyProto updatedProfile = request.getFacultyProfile();
+
+      if (!facultyService.existsByEmail(request.getUserEmail())) {
+        throw new IllegalArgumentException(
+            String.format("Could not find faculty with email: %s", request.getUserEmail()));
+      }
+
+      Faculty existingFaculty = facultyService.getFacultyByEmail(request.getUserEmail());
+      existingFaculty.setFirstName(updatedProfile.getFirstName());
+      existingFaculty.setLastName(updatedProfile.getLastName());
+
+      Set<Department> updatedDepartments =
+          updatedProfile.getDepartmentsList().stream()
+              .map(
+                  departmentName ->
+                      departmentService
+                          .getDepartmentByName(departmentName)
+                          .orElseThrow(
+                              () ->
+                                  new IllegalArgumentException(
+                                      "Department not found: " + departmentName)))
+              .collect(Collectors.toSet());
+      existingFaculty.setDepartments(updatedDepartments);
+
+      Faculty updatedFaculty = facultyService.saveFaculty(existingFaculty);
+
+      return EditProfileResponse.newBuilder()
+          .setSuccess(true)
+          .setProfileId(updatedFaculty.getId())
+          .setEditedFaculty(updatedProfile)
+          .build();
+    } catch (Exception e) {
+      return EditProfileResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMessage(e.getMessage())
+          .build();
+    }
+  }
+
+  private void validateUserRole(String userEmail) {
+    if (userService.getUserRoleByEmail(userEmail) != UserRole.FACULTY) {
+      throw new IllegalArgumentException("User must be Faculty");
+    }
+  }
+
+  private void validateRequest(EditProfileRequest request) {
+    if (!request.hasFacultyProfile()) {
+      throw new IllegalArgumentException("EditProfile must contain 'student_profile'");
+    }
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
@@ -64,6 +64,9 @@ public class FacultyProfileEditor implements ProfileEditor {
                                   new IllegalArgumentException(
                                       "Department not found: " + departmentName)))
               .collect(Collectors.toSet());
+      if (updatedDepartments.isEmpty()) {
+        throw new IllegalArgumentException("A faculty member must belong to at least one department.");
+      }
       existingFaculty.setDepartments(updatedDepartments);
 
       Faculty updatedFaculty = facultyService.saveFaculty(existingFaculty);

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileEditor.java
@@ -1,3 +1,11 @@
+/**
+ * Profile editor for faculty. This class handles editing student profiles and
+ * saving the changes to the database.
+ *
+ * Implements ProfileEditor interface.
+ *
+ * @author Augusto Escudero
+ */
 package COMP_49X_our_search.backend.profile;
 
 import COMP_49X_our_search.backend.database.entities.Department;

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/ProfileModuleController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/ProfileModuleController.java
@@ -53,10 +53,11 @@ public class ProfileModuleController implements ModuleController {
   @Autowired
   public ProfileModuleController(
       StudentProfileCreator studentProfileCreator,
-      FacultyProfileCreator facultyProfileCreator,
       StudentProfileRetriever studentProfileRetriever,
       StudentProfileEditor studentProfileEditor,
       StudentProfileDeleter studentProfileDeleter,
+      FacultyProfileCreator facultyProfileCreator,
+      FacultyProfileEditor facultyProfileEditor,
       UserService userService) {
     this.userService = userService;
     // Initialize EnumMaps for mapping profile operations to their respective
@@ -81,6 +82,7 @@ public class ProfileModuleController implements ModuleController {
 
     // Map User role to their respective ProfileEditor implementations
     this.profileEditorMap.put(UserRole.STUDENT, studentProfileEditor);
+    this.profileEditorMap.put(UserRole.FACULTY, facultyProfileEditor);
 
     // Map User role to their respective ProfileDeleter implementations
     this.profileDeleterMap.put(UserRole.STUDENT, studentProfileDeleter);

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/FacultyServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/FacultyServiceTest.java
@@ -1,0 +1,98 @@
+package COMP_49X_our_search.backend.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.repositories.FacultyRepository;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = {FacultyService.class})
+@ActiveProfiles("test")
+public class FacultyServiceTest {
+
+  @Autowired private FacultyService facultyService;
+  @MockBean private FacultyRepository facultyRepository;
+  private Faculty faculty;
+
+  @BeforeEach
+  void setUp() {
+    faculty = new Faculty();
+    faculty.setFirstName("First");
+    faculty.setLastName("Last");
+    faculty.setEmail("flast@test.com");
+  }
+
+  @Test
+  void testExistsByEmail_existingFaculty_returnsTrue() {
+    when(facultyRepository.existsByEmail(faculty.getEmail())).thenReturn(true);
+
+    boolean exists = facultyService.existsByEmail(faculty.getEmail());
+
+    assertTrue(exists);
+    verify(facultyRepository, times(1)).existsByEmail(faculty.getEmail());
+  }
+
+  @Test
+  void testExistsByEmail_nonExistingFaculty_returnsFalse() {
+    when(facultyRepository.existsByEmail("nonexistent@test.com")).thenReturn(false);
+
+    boolean exists = facultyService.existsByEmail("nonexistent@test.com");
+
+    assertFalse(exists);
+    verify(facultyRepository, times(1)).existsByEmail("nonexistent@test.com");
+  }
+
+  @Test
+  void testSaveFaculty_returnsSavedFaculty() {
+    when(facultyRepository.save(any(Faculty.class))).thenReturn(faculty);
+
+    Faculty savedFaculty = facultyService.saveFaculty(faculty);
+
+    assertNotNull(savedFaculty);
+    assertEquals(faculty.getEmail(), savedFaculty.getEmail());
+    assertEquals(faculty.getFirstName(), savedFaculty.getFirstName());
+    assertEquals(faculty.getLastName(), savedFaculty.getLastName());
+
+    verify(facultyRepository, times(1)).save(faculty);
+  }
+
+  @Test
+  void testGetFacultyByEmail_existingFaculty_returnsFaculty() {
+    when(facultyRepository.findFacultyByEmail(faculty.getEmail())).thenReturn(Optional.of(faculty));
+
+    Faculty retrievedFaculty = facultyService.getFacultyByEmail(faculty.getEmail());
+
+    assertNotNull(retrievedFaculty);
+    assertEquals(faculty.getEmail(), retrievedFaculty.getEmail());
+
+    verify(facultyRepository, times(1)).findFacultyByEmail(faculty.getEmail());
+  }
+
+  @Test
+  void testGetFacultyByEmail_nonExistingFaculty_throwsException() {
+    String nonExistingEmail = "nonexistent@test.com";
+    when(facultyRepository.findFacultyByEmail(nonExistingEmail)).thenReturn(Optional.empty());
+
+    Exception exception =
+        assertThrows(
+            RuntimeException.class, () -> facultyService.getFacultyByEmail(nonExistingEmail));
+
+    assertEquals("Faculty not found with email: " + nonExistingEmail, exception.getMessage());
+    verify(facultyRepository, times(1)).findFacultyByEmail(nonExistingEmail);
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -20,6 +20,7 @@ import COMP_49X_our_search.backend.database.services.ResearchPeriodService;
 import COMP_49X_our_search.backend.database.services.UmbrellaTopicService;
 import COMP_49X_our_search.backend.gateway.dto.CreateFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.CreateStudentRequestDTO;
+import COMP_49X_our_search.backend.gateway.dto.EditFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.EditStudentRequestDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
@@ -56,156 +57,42 @@ import proto.profile.ProfileModule.RetrieveProfileResponse;
 @ActiveProfiles("test")
 public class GatewayControllerTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-    @Autowired
-    private MockMvc mockMvc;
-    @MockBean
-    private ModuleInvoker moduleInvoker;
-    private ModuleResponse mockModuleResponseWithProjects;
-    private ModuleResponse mockModuleResponseWithStudents;
-    @MockBean
-    private ClientRegistrationRepository clientRegistrationRepository;
-    @MockBean
-    private ResearchPeriodService researchPeriodService;
-    @MockBean
-    private DepartmentService departmentService;
-    @MockBean
-    private MajorService majorService;
-    @MockBean
-    private UmbrellaTopicService umbrellaTopicService;
-    @MockBean
-    private DisciplineService disciplineService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  @Autowired private MockMvc mockMvc;
+  @MockBean private ModuleInvoker moduleInvoker;
+  private ModuleResponse mockModuleResponseWithProjects;
+  private ModuleResponse mockModuleResponseWithStudents;
+  @MockBean private ClientRegistrationRepository clientRegistrationRepository;
+  @MockBean private ResearchPeriodService researchPeriodService;
+  @MockBean private DepartmentService departmentService;
+  @MockBean private MajorService majorService;
+  @MockBean private UmbrellaTopicService umbrellaTopicService;
+  @MockBean private DisciplineService disciplineService;
 
-    @BeforeEach
-    void setUp() {
-        FacultyProto faculty = FacultyProto.newBuilder().setFirstName("Dr.")
-                .setLastName("Faculty").setEmail("faculty@test.com").build();
+  @BeforeEach
+  void setUp() {
+    FacultyProto faculty =
+        FacultyProto.newBuilder()
+            .setFirstName("Dr.")
+            .setLastName("Faculty")
+            .setEmail("faculty@test.com")
+            .build();
 
-        ProjectProto project = ProjectProto.newBuilder().setProjectId(1)
-                .setProjectName("AI Project")
-                .setDescription("Research in AI and Machine Learning")
-                .setDesiredQualifications(
-                        "Knowledge of ML and basic AI algorithms")
-                .setIsActive(true).addMajors("Computer Science")
-                .addUmbrellaTopics("AI").addResearchPeriods("Fall 2025")
-                .setFaculty(faculty).build();
-
-        StudentProto student = StudentProto.newBuilder()
-            .setFirstName("First")
-            .setLastName("Last")
-            .setEmail("flast@test.com")
-            .setClassStatus("Senior")
-            .setGraduationYear(2025)
+    ProjectProto project =
+        ProjectProto.newBuilder()
+            .setProjectId(1)
+            .setProjectName("AI Project")
+            .setDescription("Research in AI and Machine Learning")
+            .setDesiredQualifications("Knowledge of ML and basic AI algorithms")
+            .setIsActive(true)
             .addMajors("Computer Science")
-            .addResearchFieldInterests("Computer Science")
-            .addResearchPeriodsInterests("Fall 2025")
-            .setInterestReason("Test reason")
-            .setHasPriorExperience(true)
-            .setIsActive(true).build();
+            .addUmbrellaTopics("AI")
+            .addResearchPeriods("Fall 2025")
+            .setFaculty(faculty)
+            .build();
 
-        MajorProto major = MajorProto.newBuilder().setMajorId(1)
-                .setMajorName("Computer Science").build();
-
-        MajorWithEntityCollection majorWithProjects = MajorWithEntityCollection.newBuilder()
-                .setMajor(major).setProjectCollection(ProjectCollection.newBuilder().addProjects(project)).build();
-
-        MajorWithEntityCollection majorWithStudents = MajorWithEntityCollection.newBuilder()
-            .setMajor(major).setStudentCollection(StudentCollection.newBuilder().addStudents(student)).build();
-
-        DisciplineProto discipline = DisciplineProto.newBuilder()
-                .setDisciplineId(1).setDisciplineName("Engineering").build();
-
-        DisciplineWithMajors disciplineWithMajorsAndProjects =
-                DisciplineWithMajors.newBuilder().setDiscipline(discipline)
-                        .addMajors(majorWithProjects).build();
-
-        DisciplineWithMajors disciplineWithMajorsAndStudents =
-            DisciplineWithMajors.newBuilder().setDiscipline(discipline)
-                .addMajors(majorWithStudents).build();
-
-        ProjectHierarchy projectHierarchyWithProjects = ProjectHierarchy.newBuilder()
-                .addDisciplines(disciplineWithMajorsAndProjects).build();
-
-        ProjectHierarchy projectHierarchyWithStudents = ProjectHierarchy.newBuilder()
-            .addDisciplines(disciplineWithMajorsAndStudents).build();
-
-        mockModuleResponseWithProjects = ModuleResponse.newBuilder()
-                .setFetcherResponse(FetcherResponse.newBuilder()
-                        .setProjectHierarchy(projectHierarchyWithProjects))
-                .build();
-
-        mockModuleResponseWithStudents = ModuleResponse.newBuilder()
-            .setFetcherResponse(FetcherResponse.newBuilder().setProjectHierarchy(projectHierarchyWithStudents)).build();
-    }
-
-    @Test
-    @WithMockUser // include this annotation to mock that a user is authenticated to access the protected endpoints of the application
-    void getProjects_returnsExpectedResult() throws Exception {
-        when(moduleInvoker.processConfig(
-                any(ModuleConfig.class)))
-                        .thenReturn(mockModuleResponseWithProjects);
-
-        mockMvc.perform(get("/projects")).andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(1))
-                .andExpect(jsonPath("$[0].name").value("Engineering"))
-                .andExpect(jsonPath("$[0].majors[0].id").value(1))
-                .andExpect(jsonPath("$[0].majors[0].name")
-                        .value("Computer Science"))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].id").value(1))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].name")
-                        .value("AI Project"))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].description")
-                        .value("Research in AI and Machine Learning"))
-                .andExpect(jsonPath(
-                        "$[0].majors[0].posts[0].desiredQualifications").value(
-                                "Knowledge of ML and basic AI algorithms"))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].isActive")
-                        .value(true))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].majors[0]")
-                        .value("Computer Science"))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].umbrellaTopics[0]")
-                        .value("AI"))
-                .andExpect(
-                        jsonPath("$[0].majors[0].posts[0].researchPeriods[0]")
-                                .value("Fall 2025"))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].faculty.firstName")
-                        .value("Dr."))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].faculty.lastName")
-                        .value("Faculty"))
-                .andExpect(jsonPath("$[0].majors[0].posts[0].faculty.email")
-                        .value("faculty@test.com"));
-    }
-
-    @Test
-    @WithMockUser
-    void getStudents_returnsExpectedResult() throws Exception {
-        when(moduleInvoker.processConfig(
-            any(ModuleConfig.class)))
-            .thenReturn(mockModuleResponseWithStudents);
-
-        mockMvc.perform(get("/students"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].id").value(1))
-            .andExpect(jsonPath("$[0].name").value("Engineering"))
-            .andExpect(jsonPath("$[0].majors[0].id").value(1))
-            .andExpect(jsonPath("$[0].majors[0].name").value("Computer Science"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].firstName").value("First"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].lastName").value("Last"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].email").value("flast@test.com"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].classStatus").value("Senior"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].graduationYear").value(2025))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].majors[0]").value("Computer Science"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].researchFieldInterests[0]").value("Computer Science"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].researchPeriodsInterest[0]").value("Fall 2025"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].interestReason").value("Test reason"))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].hasPriorExperience").value(true))
-            .andExpect(jsonPath("$[0].majors[0].posts[0].isActive").value(true));
-    }
-
-    @Test
-    @WithMockUser
-    void createStudent_returnsExpectedResult() throws Exception {
-        StudentProto createdStudent = StudentProto.newBuilder()
+    StudentProto student =
+        StudentProto.newBuilder()
             .setFirstName("First")
             .setLastName("Last")
             .setEmail("flast@test.com")
@@ -219,82 +106,216 @@ public class GatewayControllerTest {
             .setIsActive(true)
             .build();
 
-        CreateProfileResponse createProfileResponse = CreateProfileResponse.newBuilder()
+    MajorProto major =
+        MajorProto.newBuilder().setMajorId(1).setMajorName("Computer Science").build();
+
+    MajorWithEntityCollection majorWithProjects =
+        MajorWithEntityCollection.newBuilder()
+            .setMajor(major)
+            .setProjectCollection(ProjectCollection.newBuilder().addProjects(project))
+            .build();
+
+    MajorWithEntityCollection majorWithStudents =
+        MajorWithEntityCollection.newBuilder()
+            .setMajor(major)
+            .setStudentCollection(StudentCollection.newBuilder().addStudents(student))
+            .build();
+
+    DisciplineProto discipline =
+        DisciplineProto.newBuilder().setDisciplineId(1).setDisciplineName("Engineering").build();
+
+    DisciplineWithMajors disciplineWithMajorsAndProjects =
+        DisciplineWithMajors.newBuilder()
+            .setDiscipline(discipline)
+            .addMajors(majorWithProjects)
+            .build();
+
+    DisciplineWithMajors disciplineWithMajorsAndStudents =
+        DisciplineWithMajors.newBuilder()
+            .setDiscipline(discipline)
+            .addMajors(majorWithStudents)
+            .build();
+
+    ProjectHierarchy projectHierarchyWithProjects =
+        ProjectHierarchy.newBuilder().addDisciplines(disciplineWithMajorsAndProjects).build();
+
+    ProjectHierarchy projectHierarchyWithStudents =
+        ProjectHierarchy.newBuilder().addDisciplines(disciplineWithMajorsAndStudents).build();
+
+    mockModuleResponseWithProjects =
+        ModuleResponse.newBuilder()
+            .setFetcherResponse(
+                FetcherResponse.newBuilder().setProjectHierarchy(projectHierarchyWithProjects))
+            .build();
+
+    mockModuleResponseWithStudents =
+        ModuleResponse.newBuilder()
+            .setFetcherResponse(
+                FetcherResponse.newBuilder().setProjectHierarchy(projectHierarchyWithStudents))
+            .build();
+  }
+
+  @Test
+  @WithMockUser // include this annotation to mock that a user is authenticated to access the
+                // protected endpoints of the application
+  void getProjects_returnsExpectedResult() throws Exception {
+    when(moduleInvoker.processConfig(any(ModuleConfig.class)))
+        .thenReturn(mockModuleResponseWithProjects);
+
+    mockMvc
+        .perform(get("/projects"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].name").value("Engineering"))
+        .andExpect(jsonPath("$[0].majors[0].id").value(1))
+        .andExpect(jsonPath("$[0].majors[0].name").value("Computer Science"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].id").value(1))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].name").value("AI Project"))
+        .andExpect(
+            jsonPath("$[0].majors[0].posts[0].description")
+                .value("Research in AI and Machine Learning"))
+        .andExpect(
+            jsonPath("$[0].majors[0].posts[0].desiredQualifications")
+                .value("Knowledge of ML and basic AI algorithms"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].isActive").value(true))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].majors[0]").value("Computer Science"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].umbrellaTopics[0]").value("AI"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].researchPeriods[0]").value("Fall 2025"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].faculty.firstName").value("Dr."))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].faculty.lastName").value("Faculty"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].faculty.email").value("faculty@test.com"));
+  }
+
+  @Test
+  @WithMockUser
+  void getStudents_returnsExpectedResult() throws Exception {
+    when(moduleInvoker.processConfig(any(ModuleConfig.class)))
+        .thenReturn(mockModuleResponseWithStudents);
+
+    mockMvc
+        .perform(get("/students"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].name").value("Engineering"))
+        .andExpect(jsonPath("$[0].majors[0].id").value(1))
+        .andExpect(jsonPath("$[0].majors[0].name").value("Computer Science"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].firstName").value("First"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].lastName").value("Last"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].email").value("flast@test.com"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].classStatus").value("Senior"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].graduationYear").value(2025))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].majors[0]").value("Computer Science"))
+        .andExpect(
+            jsonPath("$[0].majors[0].posts[0].researchFieldInterests[0]").value("Computer Science"))
+        .andExpect(
+            jsonPath("$[0].majors[0].posts[0].researchPeriodsInterest[0]").value("Fall 2025"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].interestReason").value("Test reason"))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].hasPriorExperience").value(true))
+        .andExpect(jsonPath("$[0].majors[0].posts[0].isActive").value(true));
+  }
+
+  @Test
+  @WithMockUser
+  void createStudent_returnsExpectedResult() throws Exception {
+    StudentProto createdStudent =
+        StudentProto.newBuilder()
+            .setFirstName("First")
+            .setLastName("Last")
+            .setEmail("flast@test.com")
+            .setClassStatus("Senior")
+            .setGraduationYear(2025)
+            .addMajors("Computer Science")
+            .addResearchFieldInterests("Computer Science")
+            .addResearchPeriodsInterests("Fall 2025")
+            .setInterestReason("Test reason")
+            .setHasPriorExperience(true)
+            .setIsActive(true)
+            .build();
+
+    CreateProfileResponse createProfileResponse =
+        CreateProfileResponse.newBuilder()
             .setSuccess(true)
             .setCreatedStudent(createdStudent)
             .build();
 
-        ModuleResponse moduleResponse = ModuleResponse.newBuilder()
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder()
             .setProfileResponse(
-                ProfileResponse.newBuilder()
-                    .setCreateProfileResponse(createProfileResponse)
-            ).build();
+                ProfileResponse.newBuilder().setCreateProfileResponse(createProfileResponse))
+            .build();
 
-        when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
 
-        CreateStudentRequestDTO requestDTO = new CreateStudentRequestDTO();
-        requestDTO.setName("First Last");
-        requestDTO.setClassStatus("Senior");
-        requestDTO.setGraduationYear("2025");
-        requestDTO.setHasPriorExperience("yes");
-        requestDTO.setInterestReason("Test reason");
-        requestDTO.setMajor(List.of("Computer Science"));
-        requestDTO.setResearchFieldInterests(List.of("Computer Science"));
-        requestDTO.setResearchPeriodsInterest(List.of("Fall 2025"));
+    CreateStudentRequestDTO requestDTO = new CreateStudentRequestDTO();
+    requestDTO.setName("First Last");
+    requestDTO.setClassStatus("Senior");
+    requestDTO.setGraduationYear("2025");
+    requestDTO.setHasPriorExperience("yes");
+    requestDTO.setInterestReason("Test reason");
+    requestDTO.setMajor(List.of("Computer Science"));
+    requestDTO.setResearchFieldInterests(List.of("Computer Science"));
+    requestDTO.setResearchPeriodsInterest(List.of("Fall 2025"));
 
-        mockMvc.perform(post("/api/studentProfiles")
+    mockMvc
+        .perform(
+            post("/api/studentProfiles")
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(requestDTO)))
-            .andExpect(status().isCreated()) // Expect HTTP 201 Created
-            .andExpect(jsonPath("$.name").value("First Last"))
-            .andExpect(jsonPath("$.classStatus").value("Senior"))
-            .andExpect(jsonPath("$.graduationYear").value("2025"))
-            .andExpect(jsonPath("$.hasPriorExperience").value("yes"))
-            .andExpect(jsonPath("$.interestReason").value("Test reason"))
-            .andExpect(jsonPath("$.major[0]").value("Computer Science"))
-            .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
-            .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
-    }
+        .andExpect(status().isCreated()) // Expect HTTP 201 Created
+        .andExpect(jsonPath("$.name").value("First Last"))
+        .andExpect(jsonPath("$.classStatus").value("Senior"))
+        .andExpect(jsonPath("$.graduationYear").value("2025"))
+        .andExpect(jsonPath("$.hasPriorExperience").value("yes"))
+        .andExpect(jsonPath("$.interestReason").value("Test reason"))
+        .andExpect(jsonPath("$.major[0]").value("Computer Science"))
+        .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
+        .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
+  }
 
-    @Test
-    @WithMockUser
-    void createFaculty_returnsExpectedResult() throws Exception {
-        FacultyProto createdFaculty = FacultyProto.newBuilder()
+  @Test
+  @WithMockUser
+  void createFaculty_returnsExpectedResult() throws Exception {
+    FacultyProto createdFaculty =
+        FacultyProto.newBuilder()
             .setFirstName("John")
             .setLastName("Doe")
             .setEmail("johndoe@test.com")
             .addDepartments("Computer Science")
             .build();
 
-        CreateProfileResponse createProfileResponse = CreateProfileResponse.newBuilder()
+    CreateProfileResponse createProfileResponse =
+        CreateProfileResponse.newBuilder()
             .setSuccess(true)
             .setCreatedFaculty(createdFaculty)
             .build();
 
-        ModuleResponse moduleResponse = ModuleResponse.newBuilder()
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder()
             .setProfileResponse(
-                ProfileResponse.newBuilder()
-                    .setCreateProfileResponse(createProfileResponse)
-            ).build();
+                ProfileResponse.newBuilder().setCreateProfileResponse(createProfileResponse))
+            .build();
 
-        when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
 
-        CreateFacultyRequestDTO requestDTO = new CreateFacultyRequestDTO();
-        requestDTO.setName("John Doe");
-        requestDTO.setDepartment(List.of("Computer Science"));
+    CreateFacultyRequestDTO requestDTO = new CreateFacultyRequestDTO();
+    requestDTO.setName("John Doe");
+    requestDTO.setDepartment(List.of("Computer Science"));
 
-        mockMvc.perform(post("/api/facultyProfiles")
+    mockMvc
+        .perform(
+            post("/api/facultyProfiles")
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(requestDTO)))
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.name").value("John Doe"))
-            .andExpect(jsonPath("$.department[0]").value("Computer Science"));
-    }
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.name").value("John Doe"))
+        .andExpect(jsonPath("$.department[0]").value("Computer Science"));
+  }
 
-    @Test
-    @WithMockUser
-    void getCurrentProfile_returnsExpectedResult() throws Exception {
-        StudentProto retrievedStudent = StudentProto.newBuilder()
+  @Test
+  @WithMockUser
+  void getCurrentProfile_returnsExpectedResult() throws Exception {
+    StudentProto retrievedStudent =
+        StudentProto.newBuilder()
             .setFirstName("First")
             .setLastName("Last")
             .setEmail("flast@test.com")
@@ -308,93 +329,97 @@ public class GatewayControllerTest {
             .setIsActive(true)
             .build();
 
-        RetrieveProfileResponse retrieveProfileResponse = RetrieveProfileResponse.newBuilder()
+    RetrieveProfileResponse retrieveProfileResponse =
+        RetrieveProfileResponse.newBuilder()
             .setSuccess(true)
             .setRetrievedStudent(retrievedStudent)
             .build();
 
-        ProfileResponse profileResponse = ProfileResponse.newBuilder()
-            .setRetrieveProfileResponse(retrieveProfileResponse)
-            .build();
+    ProfileResponse profileResponse =
+        ProfileResponse.newBuilder().setRetrieveProfileResponse(retrieveProfileResponse).build();
 
-        ModuleResponse moduleResponse = ModuleResponse.newBuilder()
-            .setProfileResponse(profileResponse)
-            .build();
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder().setProfileResponse(profileResponse).build();
 
-        when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
 
-        mockMvc.perform(get("/api/studentProfiles/current"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.firstName").value("First"))
-            .andExpect(jsonPath("$.lastName").value("Last"))
-            .andExpect(jsonPath("$.classStatus").value("Senior"))
-            .andExpect(jsonPath("$.email").value("flast@test.com"))
-            .andExpect(jsonPath("$.graduationYear").value(2025))
-            .andExpect(jsonPath("$.hasPriorExperience").value(true))
-            .andExpect(jsonPath("$.isActive").value(true))
-            .andExpect(jsonPath("$.interestReason").value("Test reason"))
-            .andExpect(jsonPath("$.majors[0]").value("Computer Science"))
-            .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
-            .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
-    }
+    mockMvc
+        .perform(get("/api/studentProfiles/current"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.firstName").value("First"))
+        .andExpect(jsonPath("$.lastName").value("Last"))
+        .andExpect(jsonPath("$.classStatus").value("Senior"))
+        .andExpect(jsonPath("$.email").value("flast@test.com"))
+        .andExpect(jsonPath("$.graduationYear").value(2025))
+        .andExpect(jsonPath("$.hasPriorExperience").value(true))
+        .andExpect(jsonPath("$.isActive").value(true))
+        .andExpect(jsonPath("$.interestReason").value("Test reason"))
+        .andExpect(jsonPath("$.majors[0]").value("Computer Science"))
+        .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
+        .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
+  }
 
-    @Test
-    @WithMockUser
-    void getResearchPeriods_returnsExpectedSuccess() throws Exception {
-        ResearchPeriod period1 = new ResearchPeriod(1, "Period 1");
-        ResearchPeriod period2 = new ResearchPeriod(2, "Period 2");
-        List<ResearchPeriod> researchPeriods = List.of(period1, period2);
+  @Test
+  @WithMockUser
+  void getResearchPeriods_returnsExpectedSuccess() throws Exception {
+    ResearchPeriod period1 = new ResearchPeriod(1, "Period 1");
+    ResearchPeriod period2 = new ResearchPeriod(2, "Period 2");
+    List<ResearchPeriod> researchPeriods = List.of(period1, period2);
 
-        when(researchPeriodService.getAllResearchPeriods()).thenReturn(researchPeriods);
+    when(researchPeriodService.getAllResearchPeriods()).thenReturn(researchPeriods);
 
-        mockMvc.perform(get("/research-periods"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].id").value(period1.getId()))
-                .andExpect(jsonPath("$[1].id").value(period2.getId()))
-                .andExpect(jsonPath("$[0].name").value(period1.getName()))
-                .andExpect(jsonPath("$[1].name").value(period2.getName()));
-    }
+    mockMvc
+        .perform(get("/research-periods"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(period1.getId()))
+        .andExpect(jsonPath("$[1].id").value(period2.getId()))
+        .andExpect(jsonPath("$[0].name").value(period1.getName()))
+        .andExpect(jsonPath("$[1].name").value(period2.getName()));
+  }
 
-    @Test
-    @WithMockUser
-    void getDepartments_returnsExpectedSuccess() throws Exception {
-        Department dept1 = new Department(1, "Engineering, Math, and Life Sciences");
-        Department dept2 = new Department(2, "Visual Arts");
-        List<Department> departments = List.of(dept1, dept2);
+  @Test
+  @WithMockUser
+  void getDepartments_returnsExpectedSuccess() throws Exception {
+    Department dept1 = new Department(1, "Engineering, Math, and Life Sciences");
+    Department dept2 = new Department(2, "Visual Arts");
+    List<Department> departments = List.of(dept1, dept2);
 
-        when(departmentService.getAllDepartments()).thenReturn(departments);
+    when(departmentService.getAllDepartments()).thenReturn(departments);
 
-        mockMvc.perform(get("/departments"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].id").value(dept1.getId()))
-                .andExpect(jsonPath("$[1].id").value(dept2.getId()))
-                .andExpect(jsonPath("$[0].name").value(dept1.getName()))
-                .andExpect(jsonPath("$[1].name").value(dept2.getName()));
-    }
+    mockMvc
+        .perform(get("/departments"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(dept1.getId()))
+        .andExpect(jsonPath("$[1].id").value(dept2.getId()))
+        .andExpect(jsonPath("$[0].name").value(dept1.getName()))
+        .andExpect(jsonPath("$[1].name").value(dept2.getName()));
+  }
 
-    @Test
-    @WithMockUser
-    void getMajors_returnsExpectedSuccess() throws Exception {
-        Major major1 = new Major(1, "Computer Science");
-        Major major2 = new Major(2, "Math");
-        List<Major> majors = List.of(major1, major2);
-        when(majorService.getAllMajors()).thenReturn(majors);
+  @Test
+  @WithMockUser
+  void getMajors_returnsExpectedSuccess() throws Exception {
+    Major major1 = new Major(1, "Computer Science");
+    Major major2 = new Major(2, "Math");
+    List<Major> majors = List.of(major1, major2);
+    when(majorService.getAllMajors()).thenReturn(majors);
 
-        mockMvc.perform(get("/majors"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].id").value(major1.getId()))
-                .andExpect(jsonPath("$[1].id").value(major2.getId()))
-                .andExpect(jsonPath("$[0].name").value(major1.getName()))
-                .andExpect(jsonPath("$[1].name").value(major2.getName()));
-    }
-  
+    mockMvc
+        .perform(get("/majors"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(major1.getId()))
+        .andExpect(jsonPath("$[1].id").value(major2.getId()))
+        .andExpect(jsonPath("$[0].name").value(major1.getName()))
+        .andExpect(jsonPath("$[1].name").value(major2.getName()));
+  }
+
   @Test
   @WithMockUser
   void editStudentProfile_returnsExpectedResult() throws Exception {
-        StudentProto editedStudent = StudentProto.newBuilder()
+    StudentProto editedStudent =
+        StudentProto.newBuilder()
             .setFirstName("UpdatedFirst")
             .setLastName("UpdatedLast")
             .setEmail("flast@test.com")
@@ -408,77 +433,118 @@ public class GatewayControllerTest {
             .setIsActive(true)
             .build();
 
-        EditProfileResponse editProfileResponse = EditProfileResponse.newBuilder()
-            .setSuccess(true)
-            .setEditedStudent(editedStudent)
+    EditProfileResponse editProfileResponse =
+        EditProfileResponse.newBuilder().setSuccess(true).setEditedStudent(editedStudent).build();
+
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder()
+            .setProfileResponse(
+                ProfileResponse.newBuilder().setEditProfileResponse(editProfileResponse))
             .build();
 
-        ModuleResponse moduleResponse = ModuleResponse.newBuilder()
-            .setProfileResponse(
-                ProfileResponse.newBuilder().setEditProfileResponse(editProfileResponse)
-            ).build();
-
-        when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
 
     EditStudentRequestDTO requestDTO = new EditStudentRequestDTO();
-        requestDTO.setName("UpdatedFirst UpdatedLast");
-        requestDTO.setClassStatus("Senior");
-        requestDTO.setGraduationYear("2025");
-        requestDTO.setHasPriorExperience("yes");
-        requestDTO.setIsActive("yes");
-        requestDTO.setInterestReason("New reason");
-        requestDTO.setMajor(List.of("Computer Science"));
-        requestDTO.setResearchFieldInterests(List.of("Computer Science"));
-        requestDTO.setResearchPeriodsInterest(List.of("Fall 2025"));
+    requestDTO.setName("UpdatedFirst UpdatedLast");
+    requestDTO.setClassStatus("Senior");
+    requestDTO.setGraduationYear("2025");
+    requestDTO.setHasPriorExperience("yes");
+    requestDTO.setIsActive("yes");
+    requestDTO.setInterestReason("New reason");
+    requestDTO.setMajor(List.of("Computer Science"));
+    requestDTO.setResearchFieldInterests(List.of("Computer Science"));
+    requestDTO.setResearchPeriodsInterest(List.of("Fall 2025"));
 
-        mockMvc.perform(put("/api/studentProfiles/current")
+    mockMvc
+        .perform(
+            put("/api/studentProfiles/current")
                 .contentType("application/json")
                 .content(objectMapper.writeValueAsString(requestDTO)))
-            .andExpect(status().isOk()) // Expect HTTP 200 OK
-            .andExpect(jsonPath("$.firstName").value("UpdatedFirst"))
-            .andExpect(jsonPath("$.lastName").value("UpdatedLast"))
-            .andExpect(jsonPath("$.email").value("flast@test.com"))
-            .andExpect(jsonPath("$.classStatus").value("Senior"))
-            .andExpect(jsonPath("$.graduationYear").value(2025))
-            .andExpect(jsonPath("$.hasPriorExperience").value(true))
-            .andExpect(jsonPath("$.isActive").value(true))
-            .andExpect(jsonPath("$.interestReason").value("New reason"))
-            .andExpect(jsonPath("$.majors[0]").value("Computer Science"))
-            .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
-            .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
+        .andExpect(status().isOk()) // Expect HTTP 200 OK
+        .andExpect(jsonPath("$.firstName").value("UpdatedFirst"))
+        .andExpect(jsonPath("$.lastName").value("UpdatedLast"))
+        .andExpect(jsonPath("$.email").value("flast@test.com"))
+        .andExpect(jsonPath("$.classStatus").value("Senior"))
+        .andExpect(jsonPath("$.graduationYear").value(2025))
+        .andExpect(jsonPath("$.hasPriorExperience").value(true))
+        .andExpect(jsonPath("$.isActive").value(true))
+        .andExpect(jsonPath("$.interestReason").value("New reason"))
+        .andExpect(jsonPath("$.majors[0]").value("Computer Science"))
+        .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
+        .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
   }
 
-    @Test
-    @WithMockUser
-    void getUmbrellaTopics_returnsExpectedSuccess() throws Exception {
-        UmbrellaTopic topic1 = new UmbrellaTopic(1, "race");
-        UmbrellaTopic topic2 = new UmbrellaTopic(2, "intersectionality");
-        List<UmbrellaTopic> topics = List.of(topic1, topic2);
-        when(umbrellaTopicService.getAllUmbrellaTopics()).thenReturn(topics);
+  @Test
+  @WithMockUser
+  void getUmbrellaTopics_returnsExpectedSuccess() throws Exception {
+    UmbrellaTopic topic1 = new UmbrellaTopic(1, "race");
+    UmbrellaTopic topic2 = new UmbrellaTopic(2, "intersectionality");
+    List<UmbrellaTopic> topics = List.of(topic1, topic2);
+    when(umbrellaTopicService.getAllUmbrellaTopics()).thenReturn(topics);
 
-        mockMvc.perform(get("/umbrella-topics"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].id").value(topic1.getId()))
-                .andExpect(jsonPath("$[1].id").value(topic2.getId()))
-                .andExpect(jsonPath("$[0].name").value(topic1.getName()))
-                .andExpect(jsonPath("$[1].name").value(topic2.getName()));
-    }
+    mockMvc
+        .perform(get("/umbrella-topics"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(topic1.getId()))
+        .andExpect(jsonPath("$[1].id").value(topic2.getId()))
+        .andExpect(jsonPath("$[0].name").value(topic1.getName()))
+        .andExpect(jsonPath("$[1].name").value(topic2.getName()));
+  }
 
-    @Test
-    @WithMockUser
-    void getDisciplines_returnsExpectedSuccess() throws Exception {
-        Discipline discipline1 = new Discipline(1, "Engineering, Math, and Life Sciences");
-        Discipline discipline2 = new Discipline(2, "Visual Arts");
-        List<Discipline> disciplines = List.of(discipline1, discipline2);
-        when(disciplineService.getAllDisciplines()).thenReturn(disciplines);
+  @Test
+  @WithMockUser
+  void getDisciplines_returnsExpectedSuccess() throws Exception {
+    Discipline discipline1 = new Discipline(1, "Engineering, Math, and Life Sciences");
+    Discipline discipline2 = new Discipline(2, "Visual Arts");
+    List<Discipline> disciplines = List.of(discipline1, discipline2);
+    when(disciplineService.getAllDisciplines()).thenReturn(disciplines);
 
-        mockMvc.perform(get("/disciplines"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].id").value(discipline1.getId()))
-                .andExpect(jsonPath("$[1].id").value(discipline2.getId()))
-                .andExpect(jsonPath("$[0].name").value(discipline1.getName()))
-                .andExpect(jsonPath("$[1].name").value(discipline2.getName()));
-    }
+    mockMvc
+        .perform(get("/disciplines"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].id").value(discipline1.getId()))
+        .andExpect(jsonPath("$[1].id").value(discipline2.getId()))
+        .andExpect(jsonPath("$[0].name").value(discipline1.getName()))
+        .andExpect(jsonPath("$[1].name").value(discipline2.getName()));
+  }
+
+  @Test
+  @WithMockUser
+  void editFacultyProfile_returnsExpectedResult() throws Exception {
+    FacultyProto editedFaculty =
+        FacultyProto.newBuilder()
+            .setFirstName("UpdatedFirst")
+            .setLastName("UpdatedLast")
+            .setEmail("faculty@test.com")
+            .addDepartments("Life and Physical Sciences")
+            .build();
+
+    EditProfileResponse editProfileResponse =
+        EditProfileResponse.newBuilder().setSuccess(true).setEditedFaculty(editedFaculty).build();
+
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder()
+            .setProfileResponse(
+                ProfileResponse.newBuilder().setEditProfileResponse(editProfileResponse))
+            .build();
+
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+
+    EditFacultyRequestDTO requestDTO = new EditFacultyRequestDTO();
+    requestDTO.setName("UpdatedFirst UpdatedLast");
+    requestDTO.setDepartment(List.of("Life and Physical Sciences"));
+
+    mockMvc
+        .perform(
+            put("/api/facultyProfiles/current")
+                .contentType("application/json")
+                .content(objectMapper.writeValueAsString(requestDTO)))
+        .andExpect(status().isOk()) // Expect HTTP 200 OK
+        .andExpect(jsonPath("$.firstName").value("UpdatedFirst"))
+        .andExpect(jsonPath("$.lastName").value("UpdatedLast"))
+        .andExpect(jsonPath("$.email").value("faculty@test.com"))
+        .andExpect(jsonPath("$.department[0]").value("Life and Physical Sciences"));
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileEditorTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileEditorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.entities.Faculty;
 import COMP_49X_our_search.backend.database.enums.UserRole;
 import COMP_49X_our_search.backend.database.services.DepartmentService;
@@ -31,6 +32,85 @@ public class FacultyProfileEditorTest {
     departmentService = mock(DepartmentService.class);
     userService = mock(UserService.class);
     facultyProfileEditor = new FacultyProfileEditor(facultyService, departmentService, userService);
+  }
+
+  @Test
+  void testEditProfile_validFacultyProfile_returnsSuccessResponse() {
+    FacultyProto updatedFacultyProto =
+        FacultyProto.newBuilder()
+            .setFirstName("UpdatedFirst")
+            .setLastName("UpdatedLast")
+            .setEmail("faculty@test.com")
+            .addDepartments("Computer Science")
+            .build();
+
+    Faculty existingFaculty = new Faculty();
+    existingFaculty.setEmail("faculty@test.com");
+    existingFaculty.setFirstName("OldFirst");
+    existingFaculty.setLastName("OldLast");
+
+    Faculty updatedFaculty = new Faculty();
+    updatedFaculty.setId(1);
+    updatedFaculty.setFirstName("UpdatedFirst");
+    updatedFaculty.setLastName("UpdatedLast");
+
+    when(userService.getUserRoleByEmail("faculty@test.com")).thenReturn(UserRole.FACULTY);
+    when(facultyService.existsByEmail("faculty@test.com")).thenReturn(true);
+    when(facultyService.getFacultyByEmail("faculty@test.com")).thenReturn(existingFaculty);
+    when(departmentService.getDepartmentByName("Computer Science"))
+        .thenReturn(Optional.of(new Department("Computer Science")));
+    when(facultyService.saveFaculty(existingFaculty)).thenReturn(updatedFaculty);
+
+    EditProfileRequest request =
+        EditProfileRequest.newBuilder()
+            .setUserEmail("faculty@test.com")
+            .setFacultyProfile(updatedFacultyProto)
+            .build();
+
+    EditProfileResponse actualResponse = facultyProfileEditor.editProfile(request);
+
+    EditProfileResponse expectedResponse =
+        EditProfileResponse.newBuilder()
+            .setSuccess(true)
+            .setProfileId(1)
+            .setEditedFaculty(updatedFacultyProto)
+            .build();
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+
+  @Test
+  void testEditProfile_emptyDepartmentList_returnsErrorResponse() {
+    FacultyProto updatedFacultyProto =
+        FacultyProto.newBuilder()
+            .setFirstName("UpdatedFirst")
+            .setLastName("UpdatedLast")
+            .setEmail("faculty@test.com")
+            .build(); // No departments added
+
+    Faculty existingFaculty = new Faculty();
+    existingFaculty.setEmail("faculty@test.com");
+
+    when(userService.getUserRoleByEmail("faculty@test.com")).thenReturn(UserRole.FACULTY);
+    when(facultyService.existsByEmail("faculty@test.com")).thenReturn(true);
+    when(facultyService.getFacultyByEmail("faculty@test.com")).thenReturn(existingFaculty);
+
+    EditProfileRequest request =
+        EditProfileRequest.newBuilder()
+            .setUserEmail("faculty@test.com")
+            .setFacultyProfile(updatedFacultyProto)
+            .build();
+
+    EditProfileResponse actualResponse = facultyProfileEditor.editProfile(request);
+
+    EditProfileResponse expectedResponse =
+        EditProfileResponse.newBuilder()
+            .setSuccess(false)
+            .setErrorMessage("A faculty member must belong to at least one department.")
+            .build();
+
+    assertEquals(expectedResponse, actualResponse);
   }
 
   @Test
@@ -127,6 +207,6 @@ public class FacultyProfileEditorTest {
             () -> {
               facultyProfileEditor.editProfile(request);
             });
-    assertTrue(exception.getMessage().contains("EditProfile must contain 'student_profile'"));
+    assertTrue(exception.getMessage().contains("EditProfile must contain 'faculty_profile'"));
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileEditorTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileEditorTest.java
@@ -1,0 +1,132 @@
+package COMP_49X_our_search.backend.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.enums.UserRole;
+import COMP_49X_our_search.backend.database.services.DepartmentService;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.UserService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import proto.data.Entities.FacultyProto;
+import proto.profile.ProfileModule.EditProfileRequest;
+import proto.profile.ProfileModule.EditProfileResponse;
+
+public class FacultyProfileEditorTest {
+
+  private FacultyService facultyService;
+  private DepartmentService departmentService;
+  private UserService userService;
+  private FacultyProfileEditor facultyProfileEditor;
+
+  @BeforeEach
+  void setUp() {
+    facultyService = mock(FacultyService.class);
+    departmentService = mock(DepartmentService.class);
+    userService = mock(UserService.class);
+    facultyProfileEditor = new FacultyProfileEditor(facultyService, departmentService, userService);
+  }
+
+  @Test
+  void testEditProfile_departmentNotFound_returnsErrorResponse() {
+    FacultyProto updatedFacultyProto =
+        FacultyProto.newBuilder()
+            .setFirstName("UpdatedFirst")
+            .setLastName("UpdatedLast")
+            .setEmail("faculty@test.com")
+            .addDepartments("Nonexistent Department")
+            .build();
+
+    Faculty existingFaculty = new Faculty();
+    existingFaculty.setEmail("faculty@test.com");
+
+    when(userService.getUserRoleByEmail("faculty@test.com")).thenReturn(UserRole.FACULTY);
+    when(facultyService.existsByEmail("faculty@test.com")).thenReturn(true);
+    when(facultyService.getFacultyByEmail("faculty@test.com")).thenReturn(existingFaculty);
+    when(departmentService.getDepartmentByName("Nonexistent Department"))
+        .thenReturn(Optional.empty());
+
+    EditProfileRequest request =
+        EditProfileRequest.newBuilder()
+            .setUserEmail("faculty@test.com")
+            .setFacultyProfile(updatedFacultyProto)
+            .build();
+
+    EditProfileResponse actualResponse = facultyProfileEditor.editProfile(request);
+
+    EditProfileResponse expectedResponse =
+        EditProfileResponse.newBuilder()
+            .setSuccess(false)
+            .setErrorMessage("Department not found: Nonexistent Department")
+            .build();
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  void testEditProfile_facultyNotFound_returnsErrorResponse() {
+    FacultyProto updatedFacultyProto =
+        FacultyProto.newBuilder()
+            .setFirstName("UpdatedFirst")
+            .setLastName("UpdatedLast")
+            .setEmail("faculty@test.com")
+            .addDepartments("Computer Science")
+            .build();
+
+    when(userService.getUserRoleByEmail("faculty@test.com")).thenReturn(UserRole.FACULTY);
+    when(facultyService.existsByEmail("faculty@test.com")).thenReturn(false);
+
+    EditProfileRequest request =
+        EditProfileRequest.newBuilder()
+            .setUserEmail("faculty@test.com")
+            .setFacultyProfile(updatedFacultyProto)
+            .build();
+
+    EditProfileResponse actualResponse = facultyProfileEditor.editProfile(request);
+
+    EditProfileResponse expectedResponse =
+        EditProfileResponse.newBuilder()
+            .setSuccess(false)
+            .setErrorMessage("Could not find faculty with email: faculty@test.com")
+            .build();
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  void testEditProfile_invalidUserRole_throwsException() {
+    EditProfileRequest request =
+        EditProfileRequest.newBuilder()
+            .setUserEmail("student@test.com")
+            .setFacultyProfile(FacultyProto.newBuilder().setFirstName("Valid Faculty"))
+            .build();
+
+    when(userService.getUserRoleByEmail("student@test.com")).thenReturn(UserRole.STUDENT);
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facultyProfileEditor.editProfile(request);
+            });
+    assertTrue(exception.getMessage().contains("User must be Faculty"));
+  }
+
+  @Test
+  void testEditProfile_invalidRequest_throwsException() {
+    EditProfileRequest request = EditProfileRequest.getDefaultInstance();
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facultyProfileEditor.editProfile(request);
+            });
+    assertTrue(exception.getMessage().contains("EditProfile must contain 'student_profile'"));
+  }
+}


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added `PUT` endpoint `/api/facultyProfiles/current` to allow faculty profile editing.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added `FacultyProfileEditor` class in the `Profile` module that implements the `ProfileEditor` interface and is responsible for editing faculty profiles, which involves updating the existing faculty data in the `faculty` table and the appropriate relationship tables in the database.
- Added extra query methods in the hibernate service to support the needed operations.

## End-to-End Testing Instructions

1. Make sure the frontend app, backend app, and the mysql database are running, and that you are logged into the app with a valid user entry in the database.
2. Send `/api/facultyProfiles/current` `PUT` request to the backend with the updated fields in the request body (see `EditFacultyRequestDTO.java` for the format).
3. Verify that the response returned the updated faculty data, which should match the data that was sent in the request.