### PR TITLE
Delete profile buttons on profile views

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -27,10 +27,10 @@ import RequireFacultyProfile from './components/Auth/RequireFacultyProfile.js'
 import FacultyProfileView from './components/FacultyProfileView.js'
 
 function App () {
-  const [isAuthenticated, setisAuthenticated] = useState(true)
+  const [isAuthenticated, setisAuthenticated] = useState(false)
   const [isStudent, setIsStudent] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
-  const [isFaculty, setIsFaculty] = useState(true)
+  const [isFaculty, setIsFaculty] = useState(false)
   const [error505, setError505] = useState(false)
   const [loading, setLoading] = useState(true) // Loading state is required to ensure that nothing loads until the call to the backend has returned a response.
 

--- a/frontend/src/__tests__/FacultyProfileView.test.js
+++ b/frontend/src/__tests__/FacultyProfileView.test.js
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import FacultyProfileView from '../components/FacultyProfileView'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
-import { mockOneActiveProject, mockThreeActiveProjects } from '../resources/mockData'
+import { mockThreeActiveProjects } from '../resources/mockData'
 
 // Need to wrap the component in this because it uses navigate from react-router-dom
 const renderWithTheme = (ui) => {

--- a/frontend/src/__tests__/FacultyProfileView.test.js
+++ b/frontend/src/__tests__/FacultyProfileView.test.js
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import FacultyProfileView from '../components/FacultyProfileView'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
-import { mockThreeActiveProjects } from '../resources/mockData'
+import { mockOneActiveProject, mockThreeActiveProjects } from '../resources/mockData'
 
 // Need to wrap the component in this because it uses navigate from react-router-dom
 const renderWithTheme = (ui) => {
@@ -18,6 +18,13 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: jest.fn()
 }))
+
+const dummyProfile = {
+  name: 'Dr. John Doe',
+  email: 'john.doe@example.com',
+  department: ['Computer Science', 'Mathematics'],
+  projects: mockThreeActiveProjects
+}
 
 describe('FacultyProfileView', () => {
   const mockNavigate = jest.fn()
@@ -77,13 +84,6 @@ describe('FacultyProfileView', () => {
   })
 
   it('displays profile data when fetch is successful', async () => {
-    const dummyProfile = {
-      name: 'Dr. John Doe',
-      email: 'john.doe@example.com',
-      department: ['Computer Science', 'Mathematics'],
-      projects: mockThreeActiveProjects
-    }
-
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => dummyProfile
@@ -134,6 +134,8 @@ describe('FacultyProfileView - Delete Profile', () => {
   })
 
   it('shows confirmation dialog when delete button is clicked', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => dummyProfile })
+
     renderWithTheme(<FacultyProfileView />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
 
@@ -144,7 +146,7 @@ describe('FacultyProfileView - Delete Profile', () => {
   })
 
   it('sends DELETE request on confirmation', async () => {
-    global.fetch.mockResolvedValueOnce({ ok: true })
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => dummyProfile })
 
     renderWithTheme(<FacultyProfileView />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
@@ -159,7 +161,15 @@ describe('FacultyProfileView - Delete Profile', () => {
   })
 
   it('displays error message if DELETE request fails', async () => {
-    global.fetch.mockResolvedValueOnce({ ok: false, statusText: 'Failed to delete' })
+    global.fetch
+      .mockResolvedValueOnce({ // Mock the profile fetch call
+        ok: true,
+        json: async () => dummyProfile
+      })
+      .mockResolvedValueOnce({ // Mock the DELETE request failure
+        ok: false,
+        statusText: 'Failed to delete'
+      })
 
     renderWithTheme(<FacultyProfileView />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
@@ -168,6 +178,12 @@ describe('FacultyProfileView - Delete Profile', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete/i }))
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+
+    // Ensure the DELETE request was made
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/facultyProfiles/current'),
+      expect.objectContaining({ method: 'DELETE', credentials: 'include' })
+    ))
 
     const failureNotices = screen.getAllByText(/Failed to delete profile\. Please try again\./i)
     expect(failureNotices).toHaveLength(2)

--- a/frontend/src/__tests__/StudentProfileView.test.js
+++ b/frontend/src/__tests__/StudentProfileView.test.js
@@ -25,6 +25,17 @@ jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn()
 }))
 
+const dummyProfile = {
+  name: 'Jane Doe',
+  graduationYear: '2025',
+  major: ['Computer Science'],
+  classStatus: 'Senior',
+  researchFieldInterests: ['Artificial Intelligence', 'Data Science'],
+  researchPeriodsInterest: ['Fall 2024'],
+  interestReason: 'I want to gain research experience.',
+  hasPriorExperience: 'yes'
+}
+
 describe('StudentProfileView', () => {
   const mockNavigate = jest.fn()
 
@@ -71,17 +82,6 @@ describe('StudentProfileView', () => {
   })
 
   it('displays profile data when fetch is successful', async () => {
-    const dummyProfile = {
-      name: 'Jane Doe',
-      graduationYear: '2025',
-      major: ['Computer Science'],
-      classStatus: 'Senior',
-      researchFieldInterests: ['Artificial Intelligence', 'Data Science'],
-      researchPeriodsInterest: ['Fall 2024'],
-      interestReason: 'I want to gain research experience.',
-      hasPriorExperience: 'yes'
-    }
-
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => dummyProfile
@@ -107,10 +107,10 @@ describe('StudentProfileView', () => {
     expect(screen.getByRole('button', { name: /Back/i })).toBeInTheDocument()
   })
 
-  it('displays "No profile found." when profile is null', async () => {
+  it('displays "No profile found." when profile is empty', async () => {
     global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => null
+      ok: false,
+      json: async () => ({})
     })
 
     renderWithTheme(<StudentProfileView />)
@@ -138,6 +138,8 @@ describe('StudentProfileView - Delete Profile', () => {
   })
 
   it('shows confirmation dialog when delete button is clicked', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => dummyProfile })
+
     renderWithTheme(<StudentProfileView />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
 
@@ -148,7 +150,7 @@ describe('StudentProfileView - Delete Profile', () => {
   })
 
   it('sends DELETE request on confirmation', async () => {
-    global.fetch.mockResolvedValueOnce({ ok: true })
+    global.fetch.mockResolvedValueOnce({ ok: true, json: async () => dummyProfile })
 
     renderWithTheme(<StudentProfileView />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
@@ -163,7 +165,15 @@ describe('StudentProfileView - Delete Profile', () => {
   })
 
   it('displays error message if DELETE request fails', async () => {
-    global.fetch.mockResolvedValueOnce({ ok: false, statusText: 'Failed to delete' })
+    global.fetch
+      .mockResolvedValueOnce({ // Mock the profile fetch call
+        ok: true,
+        json: async () => dummyProfile
+      })
+      .mockResolvedValueOnce({ // Mock the DELETE request failure
+        ok: false,
+        statusText: 'Failed to delete'
+      })
 
     renderWithTheme(<StudentProfileView />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
@@ -171,8 +181,15 @@ describe('StudentProfileView - Delete Profile', () => {
     fireEvent.click(screen.getByRole('button', { name: /delete profile/i }))
     fireEvent.click(screen.getByRole('button', { name: /delete/i }))
 
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2))
 
+    // Ensure the DELETE request was made
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/studentProfiles/current'),
+      expect.objectContaining({ method: 'DELETE', credentials: 'include' })
+    ))
+
+    // Check if error messages appear twice
     const failureNotices = screen.getAllByText(/Failed to delete profile\. Please try again\./i)
     expect(failureNotices).toHaveLength(2)
   })

--- a/frontend/src/__tests__/StudentProfileView.test.js
+++ b/frontend/src/__tests__/StudentProfileView.test.js
@@ -119,3 +119,61 @@ describe('StudentProfileView', () => {
     })
   })
 })
+
+describe('StudentProfileView - Delete Profile', () => {
+  const mockNavigate = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useNavigate.mockReturnValue(mockNavigate)
+    global.fetch = jest.fn()
+  })
+
+  it('shows the delete profile button', async () => {
+    renderWithTheme(<StudentProfileView />)
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+    const deleteButton = screen.getByRole('button', { name: /delete profile/i })
+    expect(deleteButton).toBeInTheDocument()
+  })
+
+  it('shows confirmation dialog when delete button is clicked', async () => {
+    renderWithTheme(<StudentProfileView />)
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /delete profile/i }))
+
+    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument()
+  })
+
+  it('sends DELETE request on confirmation', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: true })
+
+    renderWithTheme(<StudentProfileView />)
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /delete profile/i }))
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }))
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/studentProfiles/current'),
+      expect.objectContaining({ method: 'DELETE' })
+    ))
+  })
+
+  it('displays error message if DELETE request fails', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, statusText: 'Failed to delete' })
+
+    renderWithTheme(<StudentProfileView />)
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /delete profile/i }))
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }))
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+
+    const failureNotices = screen.getAllByText(/Failed to delete profile\. Please try again\./i)
+    expect(failureNotices).toHaveLength(2)
+  })
+})

--- a/frontend/src/components/FacultyProfileView.js
+++ b/frontend/src/components/FacultyProfileView.js
@@ -3,11 +3,16 @@
  *
  * This component fetches and displays the current faculty profile information.
  * It displays fields such as name, email, and department.
+ *
  * @author Rayan Pal
+ * @author Natalie Jungquist
  */
 
 import React, { useState, useEffect } from 'react'
-import { Box, Button, Typography, Paper, CircularProgress } from '@mui/material'
+import {
+  Box, Button, Typography, Paper, CircularProgress,
+  DialogActions, Dialog, DialogContent, DialogTitle, DialogContentText
+} from '@mui/material'
 import { backendUrl, viewProjectsFlag } from '../resources/constants'
 import { useNavigate } from 'react-router-dom'
 import PostList from './PostList'
@@ -26,6 +31,7 @@ const FacultyProfileView = () => {
   const [profile, setProfile] = useState(emptyProfile)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false)
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -49,6 +55,21 @@ const FacultyProfileView = () => {
 
   const handleBack = () => {
     navigate('/posts')
+  }
+
+  const handleDeleteProfile = async () => {
+    try {
+      const response = await fetch(`${backendUrl}/api/facultyProfiles/current`, {
+        method: 'DELETE',
+        credentials: 'include'
+      })
+      if (!response.ok) {
+        throw new Error('Failed to delete profile')
+      }
+      navigate('/') // go back to login/landing screen
+    } catch (err) {
+      setError('Failed to delete profile. Please try again.')
+    }
   }
 
   if (loading) {
@@ -122,6 +143,36 @@ const FacultyProfileView = () => {
       <Button variant='contained' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/edit-professor-profile') }}>
         Edit Profile
       </Button>
+      <Button
+        variant='contained' color='error' fullWidth sx={{ mt: 3 }}
+        disabled={profile.name === '' || error}
+        onClick={() => setOpenDeleteDialog(true)}
+      >
+        Delete Profile
+      </Button>
+
+      <Dialog open={openDeleteDialog} onClose={() => setOpenDeleteDialog(false)}>
+        <DialogTitle>Confirm Deletion</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete your profile? This action cannot be undone.
+          </DialogContentText>
+
+          {error && (
+            <Typography color='error' sx={{ mb: 2 }}>
+              {error}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDeleteDialog(false)} color='primary'>
+            Cancel
+          </Button>
+          <Button onClick={handleDeleteProfile} color='error'>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Paper>
   )
 }

--- a/frontend/src/components/FacultyProfileView.js
+++ b/frontend/src/components/FacultyProfileView.js
@@ -37,6 +37,7 @@ const FacultyProfileView = () => {
     const fetchProfile = async () => {
       try {
         const response = await fetch(`${backendUrl}/api/facultyProfiles/current`, {
+          method: 'GET',
           credentials: 'include'
         })
         if (!response.ok) {

--- a/frontend/src/components/StudentProfileEdit.js
+++ b/frontend/src/components/StudentProfileEdit.js
@@ -5,6 +5,9 @@
  * allows the user to edit their profile information (including setting the profile as inactive),
  * and submits the updated data to the backend.
  * It displays error and success messages based on the submission outcome.
+ *
+ * @author Rayan Pal
+ * @author Natalie Jungquist
  */
 
 import React, { useState, useEffect } from 'react'

--- a/frontend/src/components/StudentProfileView.js
+++ b/frontend/src/components/StudentProfileView.js
@@ -41,6 +41,7 @@ const StudentProfileView = () => {
     const fetchProfile = async () => {
       try {
         const response = await fetch(`${backendUrl}/api/studentProfiles/current`, {
+          method: 'GET',
           credentials: 'include'
         })
         if (!response.ok) {
@@ -97,7 +98,7 @@ const StudentProfileView = () => {
           {error}
         </Typography>
       )}
-      {profile
+      {profile.name !== ''
         ? (
           <Box>
             <Typography variant='body1'><strong>Name:</strong> {profile.name}</Typography>

--- a/frontend/src/components/StudentProfileView.js
+++ b/frontend/src/components/StudentProfileView.js
@@ -7,10 +7,14 @@
  * An "Edit Profile" button is provided at the bottom.
  *
  * @author Rayan Pal
+ * @author Natalie Jungquist
  */
 
 import React, { useState, useEffect } from 'react'
-import { Box, Button, Typography, Paper, CircularProgress } from '@mui/material'
+import {
+  Box, Button, Typography, Paper, CircularProgress,
+  DialogActions, Dialog, DialogContent, DialogTitle, DialogContentText
+} from '@mui/material'
 import { backendUrl } from '../resources/constants'
 import { useNavigate } from 'react-router-dom'
 
@@ -31,6 +35,7 @@ const StudentProfileView = () => {
   const [profile, setProfile] = useState(emptyProfile)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false)
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -54,6 +59,21 @@ const StudentProfileView = () => {
 
   const handleBack = () => {
     navigate('/posts')
+  }
+
+  const handleDeleteProfile = async () => {
+    try {
+      const response = await fetch(`${backendUrl}/api/studentProfiles/current`, {
+        method: 'DELETE',
+        credentials: 'include'
+      })
+      if (!response.ok) {
+        throw new Error('Failed to delete profile')
+      }
+      navigate('/')
+    } catch (err) {
+      setError('Failed to delete profile. Please try again.')
+    }
   }
 
   if (loading) {
@@ -104,6 +124,37 @@ const StudentProfileView = () => {
       <Button variant='contained' color='primary' fullWidth sx={{ mt: 3 }} onClick={() => { navigate('/edit-student-profile') }}>
         Edit Profile
       </Button>
+
+      <Button
+        variant='contained' color='error' fullWidth sx={{ mt: 3 }}
+        disabled={profile.name === '' || error}
+        onClick={() => setOpenDeleteDialog(true)}
+      >
+        Delete Profile
+      </Button>
+
+      <Dialog open={openDeleteDialog} onClose={() => setOpenDeleteDialog(false)}>
+        <DialogTitle>Confirm Deletion</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Are you sure you want to delete your profile? This action cannot be undone.
+          </DialogContentText>
+
+          {error && (
+            <Typography color='error' sx={{ mb: 2 }}>
+              {error}
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpenDeleteDialog(false)} color='primary'>
+            Cancel
+          </Button>
+          <Button onClick={handleDeleteProfile} color='error'>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Paper>
   )
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Other/new feat

**Summary:** The student and faculty profile views now have delete buttons. Popups display to confirm deletion. Error messages display if needed. These buttons were missing from original user story implementation.
NOTE there are other commits on this branch because I merged main and another branch to avoid conflicts. 

## UI/UX Implementation
Completion of UI prototype for sprint 3

## Model Updates
none

### Data Models
none

### Object-Oriented Models
none

## End-to-End Testing Instructions
1. login as student or faculty
2. go to view profile
3. see delete options