### PR TITLE
Implemented delete faculty endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FacultyRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FacultyRepository.java
@@ -15,4 +15,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface FacultyRepository extends JpaRepository<Faculty, Integer> {
   boolean existsByEmail(String email);
   Optional<Faculty> findFacultyByEmail(String email);
+  void deleteByEmail(String email);
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/FacultyService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/FacultyService.java
@@ -36,4 +36,12 @@ public class FacultyService {
         .findFacultyByEmail(email)
         .orElseThrow(() -> new RuntimeException("Faculty not found with email: " + email));
   }
+
+  public void deleteFacultyByEmail(String email) {
+    if (!facultyRepository.existsByEmail(email)) {
+      throw new RuntimeException(
+          String.format("Cannot delete faculty with email '%s'. Faculty not found.", email));
+    }
+    facultyRepository.deleteByEmail(email);
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -347,6 +347,7 @@ public class GatewayController {
     DeleteProfileResponse deleteProfileResponse =
         response.getProfileResponse().getDeleteProfileResponse();
     if (deleteProfileResponse.getSuccess()) {
+      // TODO: should log out the user I think?
       return ResponseEntity.ok(null);
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
@@ -417,6 +418,27 @@ public class GatewayController {
         response.getProfileResponse().getEditProfileResponse();
     if (editProfileResponse.getSuccess()) {
       return ResponseEntity.ok(protoFacultyToFacultyDto(editProfileResponse.getEditedFaculty()));
+    }
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+  }
+
+  @DeleteMapping("/api/facultyProfiles/current")
+  public ResponseEntity<Void> deleteFacultyProfile() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    ModuleConfig moduleConfig =
+        ModuleConfig.newBuilder()
+            .setProfileRequest(
+                ProfileRequest.newBuilder()
+                    .setDeleteProfileRequest(
+                        DeleteProfileRequest.newBuilder()
+                            .setUserEmail(oAuthChecker.getAuthUserEmail(authentication))))
+            .build();
+    ModuleResponse response = moduleInvoker.processConfig(moduleConfig);
+    DeleteProfileResponse deleteProfileResponse =
+        response.getProfileResponse().getDeleteProfileResponse();
+    if (deleteProfileResponse.getSuccess()) {
+      // TODO: should log out the user I think?
+      return ResponseEntity.ok(null);
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleter.java
@@ -1,0 +1,67 @@
+/**
+ * Profile deleter for faculty. This class handles deleting a faculty profile
+ * and its respective user from the database.
+ *
+ * Implements ProfileDeleter interface.
+ *
+ * @author Augusto Escudero
+ */
+package COMP_49X_our_search.backend.profile;
+
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.UserService;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import proto.profile.ProfileModule.DeleteProfileRequest;
+import proto.profile.ProfileModule.DeleteProfileResponse;
+
+@Service
+public class FacultyProfileDeleter implements ProfileDeleter {
+
+  private final FacultyService facultyService;
+  private final UserService userService;
+
+  @Autowired
+  public FacultyProfileDeleter(FacultyService facultyService, UserService userService) {
+    this.facultyService = facultyService;
+    this.userService = userService;
+  }
+
+  @Override
+  @Transactional
+  public DeleteProfileResponse deleteProfile(DeleteProfileRequest request) {
+    validateRequest(request);
+
+    try {
+      String email = request.getUserEmail();
+
+      if (!facultyService.existsByEmail(email)) {
+        return DeleteProfileResponse.newBuilder()
+            .setSuccess(false)
+            .setErrorMessage(String.format("Faculty with email '%s' not found.", email))
+            .build();
+      }
+
+      Faculty dbFaculty = facultyService.getFacultyByEmail(email);
+      int profileId = dbFaculty.getId();
+
+      facultyService.deleteFacultyByEmail(email);
+      userService.deleteUserByEmail(email);
+
+      return DeleteProfileResponse.newBuilder().setSuccess(true).setProfileId(profileId).build();
+    } catch (Exception e) {
+      return DeleteProfileResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMessage("Error deleting faculty profile: " + e.getMessage())
+          .build();
+    }
+  }
+
+  private void validateRequest(DeleteProfileRequest request) {
+    if (request.getUserEmail().isEmpty()) {
+      throw new IllegalArgumentException("DeleteProfileRequest must contain 'user_email'");
+    }
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/ProfileModuleController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/ProfileModuleController.java
@@ -4,9 +4,9 @@
  * requests accordingly.
  *
  * <p>Supported operations:
- * - **Profile Creation** (currently supported)
- * - **Profile Editing** (currently supported)
- * - **Profile Deletion** (currently supported)
+ * - **Profile Creation**
+ * - **Profile Editing**
+ * - **Profile Deletion**
  *
  * <p>This controller determines the profile and operation type and invokes the corresponding
  * interface ('ProfileCreator', 'ProfileEditor', 'ProfileDeleter') through a mapped implementation,

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/ProfileModuleController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/ProfileModuleController.java
@@ -58,6 +58,7 @@ public class ProfileModuleController implements ModuleController {
       StudentProfileDeleter studentProfileDeleter,
       FacultyProfileCreator facultyProfileCreator,
       FacultyProfileEditor facultyProfileEditor,
+      FacultyProfileDeleter facultyProfileDeleter,
       UserService userService) {
     this.userService = userService;
     // Initialize EnumMaps for mapping profile operations to their respective
@@ -86,6 +87,7 @@ public class ProfileModuleController implements ModuleController {
 
     // Map User role to their respective ProfileDeleter implementations
     this.profileDeleterMap.put(UserRole.STUDENT, studentProfileDeleter);
+    this.profileDeleterMap.put(UserRole.FACULTY, facultyProfileDeleter);
   }
 
   @Override

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/StudentProfileDeleter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/StudentProfileDeleter.java
@@ -1,3 +1,11 @@
+/**
+ * Profile deleter for student. This class handles deleting a student profile
+ * and its respective user from the database.
+ *
+ * Implements ProfileDeleter interface
+ *
+ * @author Augusto Escudero
+ */
 package COMP_49X_our_search.backend.profile;
 
 import COMP_49X_our_search.backend.database.entities.Student;

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/FacultyServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/FacultyServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -94,5 +95,34 @@ public class FacultyServiceTest {
 
     assertEquals("Faculty not found with email: " + nonExistingEmail, exception.getMessage());
     verify(facultyRepository, times(1)).findFacultyByEmail(nonExistingEmail);
+  }
+
+  @Test
+  void testDeleteFacultyByEmail_existingFaculty_deletesSuccessfully() {
+    String email = "faculty@test.com";
+
+    when(facultyRepository.existsByEmail(email)).thenReturn(true);
+
+    facultyService.deleteFacultyByEmail(email);
+
+    verify(facultyRepository, times(1)).existsByEmail(email);
+    verify(facultyRepository, times(1)).deleteByEmail(email);
+  }
+
+  @Test
+  void testDeleteFacultyByEmail_nonExistingFaculty_throwsException() {
+    String email = "nonexistent@test.com";
+
+    when(facultyRepository.existsByEmail(email)).thenReturn(false);
+
+    Exception exception =
+        assertThrows(RuntimeException.class, () -> facultyService.deleteFacultyByEmail(email));
+
+    assertEquals(
+        "Cannot delete faculty with email 'nonexistent@test.com'. Faculty not found.",
+        exception.getMessage());
+
+    verify(facultyRepository, times(1)).existsByEmail(email);
+    verify(facultyRepository, never()).deleteByEmail(email);
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -2,6 +2,7 @@ package COMP_49X_our_search.backend.gateway;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -48,6 +49,7 @@ import proto.fetcher.DataTypes.ProjectHierarchy;
 import proto.fetcher.DataTypes.StudentCollection;
 import proto.fetcher.FetcherModule.FetcherResponse;
 import proto.profile.ProfileModule.CreateProfileResponse;
+import proto.profile.ProfileModule.DeleteProfileResponse;
 import proto.profile.ProfileModule.EditProfileResponse;
 import proto.profile.ProfileModule.ProfileResponse;
 import proto.profile.ProfileModule.RetrieveProfileResponse;
@@ -546,5 +548,24 @@ public class GatewayControllerTest {
         .andExpect(jsonPath("$.lastName").value("UpdatedLast"))
         .andExpect(jsonPath("$.email").value("faculty@test.com"))
         .andExpect(jsonPath("$.department[0]").value("Life and Physical Sciences"));
+  }
+
+  @Test
+  @WithMockUser
+  void deleteFacultyProfile_returnsExpectedResult() throws Exception {
+    DeleteProfileResponse deleteProfileResponse =
+        DeleteProfileResponse.newBuilder().setSuccess(true).build();
+
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder()
+            .setProfileResponse(
+                ProfileResponse.newBuilder().setDeleteProfileResponse(deleteProfileResponse))
+            .build();
+
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+
+    mockMvc
+        .perform(delete("/api/facultyProfiles/current"))
+        .andExpect(status().isOk());
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleterTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleterTest.java
@@ -1,0 +1,109 @@
+package COMP_49X_our_search.backend.profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import proto.profile.ProfileModule.DeleteProfileRequest;
+import proto.profile.ProfileModule.DeleteProfileResponse;
+
+public class FacultyProfileDeleterTest {
+
+  private FacultyProfileDeleter facultyProfileDeleter;
+  private FacultyService facultyService;
+  private UserService userService;
+
+  @BeforeEach
+  void setUp() {
+    facultyService = mock(FacultyService.class);
+    userService = mock(UserService.class);
+    facultyProfileDeleter = new FacultyProfileDeleter(facultyService, userService);
+  }
+
+  @Test
+  public void testDeleteProfile_existingFaculty_deletesSuccessfully() {
+    String email = "faculty@test.com";
+    Faculty faculty = new Faculty();
+    faculty.setEmail(email);
+    faculty.setId(1);
+
+    when(facultyService.existsByEmail(email)).thenReturn(true);
+    when(facultyService.getFacultyByEmail(email)).thenReturn(faculty);
+
+    DeleteProfileRequest request = DeleteProfileRequest.newBuilder().setUserEmail(email).build();
+    DeleteProfileResponse response = facultyProfileDeleter.deleteProfile(request);
+
+    assertThat(response.getSuccess()).isTrue();
+    assertThat(response.getProfileId()).isEqualTo(1);
+    assertThat(response.getErrorMessage()).isEmpty();
+
+    verify(facultyService, times(1)).deleteFacultyByEmail(email);
+    verify(userService, times(1)).deleteUserByEmail(email);
+  }
+
+  @Test
+  public void testDeleteProfile_nonExistingFaculty_returnsExpectedError() {
+    String email = "nonexistent@test.com";
+
+    when(facultyService.existsByEmail(email)).thenReturn(false);
+
+    DeleteProfileRequest request = DeleteProfileRequest.newBuilder().setUserEmail(email).build();
+    DeleteProfileResponse response = facultyProfileDeleter.deleteProfile(request);
+
+    assertThat(response.getSuccess()).isFalse();
+    assertThat(response.getErrorMessage())
+        .contains("Faculty with email 'nonexistent@test.com' not found.");
+
+    verify(facultyService, never()).deleteFacultyByEmail(email);
+    verify(userService, never()).deleteUserByEmail(email);
+  }
+
+  @Test
+  public void testDeleteProfile_invalidRequest_throwsException() {
+    DeleteProfileRequest request = DeleteProfileRequest.newBuilder().setUserEmail("").build();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> facultyProfileDeleter.deleteProfile(request));
+
+    assertThat(exception.getMessage()).contains("DeleteProfileRequest must contain 'user_email'");
+
+    verify(facultyService, never()).deleteFacultyByEmail(any());
+    verify(userService, never()).deleteUserByEmail(any());
+  }
+
+  @Test
+  public void testDeleteProfile_facultyServiceThrowsException_returnsErrorResponse() {
+    String email = "faculty@test.com";
+    Faculty faculty = new Faculty();
+    faculty.setEmail(email);
+    faculty.setId(1);
+
+    when(facultyService.existsByEmail(email)).thenReturn(true);
+    when(facultyService.getFacultyByEmail(email)).thenReturn(faculty);
+    doThrow(new RuntimeException("Database error"))
+        .when(facultyService)
+        .deleteFacultyByEmail(email);
+
+    DeleteProfileRequest request = DeleteProfileRequest.newBuilder().setUserEmail(email).build();
+    DeleteProfileResponse response = facultyProfileDeleter.deleteProfile(request);
+
+    assertThat(response.getSuccess()).isFalse();
+    assertThat(response.getErrorMessage())
+        .contains("Error deleting faculty profile: Database error");
+
+    verify(facultyService, times(1)).deleteFacultyByEmail(email);
+    verify(userService, never()).deleteUserByEmail(email);
+  }
+}


### PR DESCRIPTION
# Overview

**Type of Change:** New feature

**Summary:** Added `DELETE` endpoint for `/api/facultyProfiles/current` to allow faculty profile and user deletion.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added `FacultyProfileDeleter` class in the `Profile` module that implements the `ProfileDeleter` interface and is responsible for deleting a faculty profile and user, which involves deleting the existing faculty data in the `users` table, and the `faculty` table and its respective relationship tables.
- Added extra query methods in the hibernate entity service to support the needed operations.

## End-to-End Testing Instructions

1. Make sure the frontend app, backend app, and the mysql database are running, and that you are logged into the app with a valid user entry in the database.
2. Send `/api/facultyProfiles/current` `DELETE` request to the backend.
3. Verify that the response returned OK.