### PR TITLE
Get disciplines endpoint also returns majors

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -379,10 +379,14 @@ public class GatewayController {
   @GetMapping("/disciplines")
   public ResponseEntity<List<DisciplineDTO>> getDisciplines() {
     try {
-      List<DisciplineDTO> disciplineDTOS =
-          disciplineService.getAllDisciplines().stream()
-              .map(discipline -> new DisciplineDTO(discipline.getId(), discipline.getName()))
-              .toList();
+      // For each discipline, get the id, name, and majors. Convert the majors to majorDTOs,
+      // then create a disciplineDTO with the id, name, and majorDTOs.
+      List<DisciplineDTO> disciplineDTOS = disciplineService.getAllDisciplines().stream()
+              .map(discipline -> {
+                List<MajorDTO> majorDTOS = majorService.getMajorsByDisciplineId(discipline.getId()).stream()
+                        .map(major -> new MajorDTO(major.getId(), major.getName())).toList();
+                return new DisciplineDTO(discipline.getId(), discipline.getName(), majorDTOS);
+              }).toList();
       return ResponseEntity.ok(disciplineDTOS);
     } catch (Exception e) {
       e.printStackTrace();

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/DisciplineDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/DisciplineDTO.java
@@ -10,9 +10,10 @@ public class DisciplineDTO {
 
   public DisciplineDTO() {}
 
-  public DisciplineDTO(int id, String name) {
+  public DisciplineDTO(int id, String name, List<MajorDTO> majors) {
     this.id = id;
     this.name = name;
+    this.majors = majors;
   }
 
   public int getId() {

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/MajorDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/MajorDTO.java
@@ -15,6 +15,11 @@ public class MajorDTO {
     this.posts = posts;
   }
 
+  public MajorDTO(Integer id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
   public int getId() {
     return id;
   }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import COMP_49X_our_search.backend.database.MajorServiceTest;
 import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Major;
@@ -500,6 +501,12 @@ public class GatewayControllerTest {
     List<Discipline> disciplines = List.of(discipline1, discipline2);
     when(disciplineService.getAllDisciplines()).thenReturn(disciplines);
 
+    Major major1 = new Major(1, "Computer Science");
+    Major major2 = new Major(2, "Math");
+    Major major3 = new Major(3, "Drawing");
+    when(majorService.getMajorsByDisciplineId(discipline1.getId())).thenReturn(List.of(major1, major2));
+    when(majorService.getMajorsByDisciplineId(discipline2.getId())).thenReturn(List.of(major3));
+
     mockMvc
         .perform(get("/disciplines"))
         .andExpect(status().isOk())
@@ -507,7 +514,15 @@ public class GatewayControllerTest {
         .andExpect(jsonPath("$[0].id").value(discipline1.getId()))
         .andExpect(jsonPath("$[1].id").value(discipline2.getId()))
         .andExpect(jsonPath("$[0].name").value(discipline1.getName()))
-        .andExpect(jsonPath("$[1].name").value(discipline2.getName()));
+        .andExpect(jsonPath("$[1].name").value(discipline2.getName()))
+        .andExpect(jsonPath("$[0].majors.length()").value(2))
+        .andExpect(jsonPath("$[0].majors[0].id").value(major1.getId()))
+        .andExpect(jsonPath("$[0].majors[0].name").value(major1.getName()))
+        .andExpect(jsonPath("$[0].majors[1].id").value(major2.getId()))
+        .andExpect(jsonPath("$[0].majors[1].name").value(major2.getName()))
+        .andExpect(jsonPath("$[1].majors.length()").value(1))
+        .andExpect(jsonPath("$[1].majors[0].id").value(major3.getId()))
+        .andExpect(jsonPath("$[1].majors[0].name").value(major3.getName()));
   }
 
   @Test


### PR DESCRIPTION
# Overview

**Type of Change:** Other

**Summary:**
The GetMapping on the backend for disciplines used to return a list of disciplines by id and name. I changed GetMapping for disciplines to return the disciplines AND their majors, not just the id and name. This will be used in the frontend's ResearchOpportunityForm. The client asked that we change it so that it can render the major selection items grouped by discipline. 

## UI/UX Implementation
No changes

## Model Updates
No changes

### Data Models
No changes

### Object-Oriented Models
No changes - I was able to reuse existing code to get majors by discipline id.

## End-to-End Testing Instructions
1. login
2. go to backendUrl/disciplines, will return list of disciplines and their majors are not null