### PR TITLE
Fixed faculty deletion not deleting projects

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/ProjectRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/ProjectRepository.java
@@ -11,9 +11,12 @@ package COMP_49X_our_search.backend.database.repositories;
 import COMP_49X_our_search.backend.database.entities.Project;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ProjectRepository extends JpaRepository<Project, Integer> {
   List<Project> findAllByDisciplines_Id(Integer disciplineId);
   List<Project> findAllByMajors_Id(Integer majorId);
   List<Project> findAllByFaculty_Id(Integer facultyId);
+  @Transactional
+  void deleteByFaculty_Id(int facultyId);
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/ProjectService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/ProjectService.java
@@ -15,6 +15,7 @@ import COMP_49X_our_search.backend.database.repositories.ProjectRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ProjectService {
@@ -37,5 +38,10 @@ public class ProjectService {
 
   public List<Project> getProjectsByFacultyId(int facultyId) {
     return projectRepository.findAllByFaculty_Id(facultyId);
+  }
+
+  @Transactional
+  public void deleteByFacultyId(int facultyId) {
+    projectRepository.deleteByFaculty_Id(facultyId);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleter.java
@@ -10,6 +10,7 @@ package COMP_49X_our_search.backend.profile;
 
 import COMP_49X_our_search.backend.database.entities.Faculty;
 import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.ProjectService;
 import COMP_49X_our_search.backend.database.services.UserService;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,11 +23,13 @@ public class FacultyProfileDeleter implements ProfileDeleter {
 
   private final FacultyService facultyService;
   private final UserService userService;
+  private final ProjectService projectService;
 
   @Autowired
-  public FacultyProfileDeleter(FacultyService facultyService, UserService userService) {
+  public FacultyProfileDeleter(FacultyService facultyService, UserService userService, ProjectService projectService) {
     this.facultyService = facultyService;
     this.userService = userService;
+    this.projectService = projectService;
   }
 
   @Override
@@ -49,6 +52,7 @@ public class FacultyProfileDeleter implements ProfileDeleter {
 
       facultyService.deleteFacultyByEmail(email);
       userService.deleteUserByEmail(email);
+      projectService.deleteByFacultyId(dbFaculty.getId());
 
       return DeleteProfileResponse.newBuilder().setSuccess(true).setProfileId(profileId).build();
     } catch (Exception e) {

--- a/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleterTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileDeleterTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import COMP_49X_our_search.backend.database.entities.Faculty;
 import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.ProjectService;
 import COMP_49X_our_search.backend.database.services.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,12 +24,14 @@ public class FacultyProfileDeleterTest {
   private FacultyProfileDeleter facultyProfileDeleter;
   private FacultyService facultyService;
   private UserService userService;
+  private ProjectService projectService;
 
   @BeforeEach
   void setUp() {
     facultyService = mock(FacultyService.class);
     userService = mock(UserService.class);
-    facultyProfileDeleter = new FacultyProfileDeleter(facultyService, userService);
+    projectService = mock(ProjectService.class);
+    facultyProfileDeleter = new FacultyProfileDeleter(facultyService, userService, projectService);
   }
 
   @Test
@@ -50,6 +53,7 @@ public class FacultyProfileDeleterTest {
 
     verify(facultyService, times(1)).deleteFacultyByEmail(email);
     verify(userService, times(1)).deleteUserByEmail(email);
+    verify(projectService, times(1)).deleteByFacultyId(faculty.getId());
   }
 
   @Test


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix.

**Summary:** Fixed a bug where calling the `Profile` module to delete a faculty profile would attempt to delete the data from the `users` table, and the `faculty` table (and its respective relationship, i.e. `faculty_department`) but would not attempt to delete the project data, which used `faculty_id` as a foreign key referencing the `id` key in the `faculty` table.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.
**NOTE**: this could also be fixed by adding this to the `Faculty.java` hibernate class:
```
@OneToMany(mappedBy = "faculty", cascade = CascadeType.ALL, orphanRemoval = true)
private Set<Project> projects = new HashSet<>();
```
However, in the future we might need to support having multiple faculty on the same project, i.e. a Many-to-many relationship, which would involve having a method in `ProjectService.java` to delete faculty from a project but not the entire project, thus making the transition into the Many-to-many relationship easier in the future.

### Object-Oriented Models

- Added extra query method in the `Project` JPA service to support deleting all projects that belong to a faculty member.

## End-to-End Testing Instructions

1. Login in the backend as Faculty.
2. Try to delete profile.
3. The faculty profile should be deleted successfully, as well as their respective projects.