### PR TITLE
updated delete current profile endpoints to cause logout

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -29,8 +29,11 @@ import COMP_49X_our_search.backend.database.services.UmbrellaTopicService;
 import COMP_49X_our_search.backend.gateway.dto.*;
 import COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -334,7 +337,7 @@ public class GatewayController {
   }
 
   @DeleteMapping("/api/studentProfiles/current")
-  public ResponseEntity<Void> deleteStudentProfile() {
+  public ResponseEntity<Void> deleteStudentProfile(HttpServletResponse res) throws IOException {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     ModuleConfig moduleConfig =
         ModuleConfig.newBuilder()
@@ -348,8 +351,9 @@ public class GatewayController {
     DeleteProfileResponse deleteProfileResponse =
         response.getProfileResponse().getDeleteProfileResponse();
     if (deleteProfileResponse.getSuccess()) {
-      // TODO: should log out the user I think?
-      return ResponseEntity.ok(null);
+      // Redirect user to the logout endpoint
+      res.sendRedirect("/logout");
+      return null; // Response is already handled by the redirection
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }
@@ -428,7 +432,7 @@ public class GatewayController {
   }
 
   @DeleteMapping("/api/facultyProfiles/current")
-  public ResponseEntity<Void> deleteFacultyProfile() {
+  public ResponseEntity<Void> deleteFacultyProfile(HttpServletResponse res) throws IOException {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     ModuleConfig moduleConfig =
         ModuleConfig.newBuilder()
@@ -442,8 +446,9 @@ public class GatewayController {
     DeleteProfileResponse deleteProfileResponse =
         response.getProfileResponse().getDeleteProfileResponse();
     if (deleteProfileResponse.getSuccess()) {
-      // TODO: should log out the user I think?
-      return ResponseEntity.ok(null);
+      // Redirect user to the logout endpoint
+      res.sendRedirect("/logout");
+      return null; // Response is already handled by the redirection
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -3,6 +3,7 @@ package COMP_49X_our_search.backend.gateway;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -569,7 +570,7 @@ public class GatewayControllerTest {
 
   @Test
   @WithMockUser
-  void deleteFacultyProfile_returnsExpectedResult() throws Exception {
+  void deleteCurrentProfile_returnsExpectedResult() throws Exception {
     DeleteProfileResponse deleteProfileResponse =
         DeleteProfileResponse.newBuilder().setSuccess(true).build();
 
@@ -583,7 +584,13 @@ public class GatewayControllerTest {
 
     mockMvc
         .perform(delete("/api/facultyProfiles/current"))
-        .andExpect(status().isOk());
+            .andExpect(status().is3xxRedirection()) // Assert redirection status
+            .andExpect(header().string("Location", "/logout"));
+
+    mockMvc
+            .perform(delete("/api/studentProfiles/current"))
+            .andExpect(status().is3xxRedirection()) // Assert redirection status
+            .andExpect(header().string("Location", "/logout"));
   }
 
   @Test

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,11 +29,12 @@ import FacultyProfileEdit from './components/profiles/FacultyProfileEdit.js'
 import ResearchOpportunityForm from './components/ResearchOpportunityForm.js'
 
 function App () {
-  const [isAuthenticated, setisAuthenticated] = useState(true)
+  const [isAuthenticated, setisAuthenticated] = useState(false)
   const [isStudent, setIsStudent] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
-  const [isFaculty, setIsFaculty] = useState(true)
-  const [error505, setError505] = useState(false)
+  const [isFaculty, setIsFaculty] = useState(false)
+  const [checkAuthError, setCheckAuthError] = useState(false)
+  const [logoutError, setLogoutError] = useState(false)
   const [loading, setLoading] = useState(true) // Loading state is required to ensure that nothing loads until the call to the backend has returned a response.
 
   // Fire these methods when the app loads
@@ -51,6 +52,7 @@ function App () {
       })
 
       if (!response.ok) {
+        console.log('check auth error')
         throw new Error('Failed to fetch authentication status')
       }
 
@@ -68,7 +70,7 @@ function App () {
       // else isAuthenticated is false
     } catch (error) {
       console.error('Error fetching checking authentication status:', error)
-      setError505(true)
+      setCheckAuthError(true)
     } finally {
       setLoading(false) // Set loading to false when check is done
     }
@@ -88,15 +90,18 @@ function App () {
       setIsFaculty(false)
       setIsAdmin(false)
 
-      await fetch(`${backendUrl}/logout`, {
+      const response = await fetch(`${backendUrl}/logout`, {
         credentials: 'include',
         method: 'POST',
         redirect: 'follow'
       })
 
-      window.location.href = '/'
+      if (!response.ok) {
+        throw new Error('Error logging out')
+      }
     } catch (error) {
-      console.error('Error logging out:', error)
+      console.error(error)
+      setLogoutError(true)
     }
   }
 
@@ -114,7 +119,7 @@ function App () {
     <Routes>
       <Route
         path='/'
-        element={<LandingPage handleLogin={handleLogin} />}
+        element={<LandingPage handleLogin={handleLogin} checkAuthError={checkAuthError} logoutError={logoutError} />}
       />
 
       <Route
@@ -166,7 +171,6 @@ function App () {
             isStudent={isStudent} isFaculty={isFaculty} isAdmin={isAdmin}
           >
             <MainLayout
-              error505={error505}
               isAuthenticated={isAuthenticated}
               handleLogin={handleLogin}
               handleLogout={handleLogout}

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -21,9 +21,29 @@ const theme = createTheme({
   }
 })
 
-function LandingPage ({ handleLogin }) {
+function LandingPage ({ handleLogin, checkAuthError, logoutError }) {
+  const renderServerErrors = () => {
+    let checkAuthErrorMessage = ''
+    let logoutErrorMessage = ''
+    if (checkAuthError) {
+      checkAuthErrorMessage = 'Sorry, we are having trouble connecting you to the server. Please try again later.'
+    }
+    if (logoutError) {
+      logoutErrorMessage = 'Sorry, we are having trouble logging you out. Please try again later.'
+    }
+    return (
+      <Box display='flex' justifyContent='center' alignItems='center' height='20vh' sx={{ bgcolor: '#e0f7fa' }}>
+        <Typography style={{ padding: '16px', color: 'red' }}>
+          {checkAuthErrorMessage}
+          {logoutErrorMessage}
+        </Typography>
+      </Box>
+    )
+  }
+
   return (
     <ThemeProvider theme={theme}>
+      {renderServerErrors()}
       <Box
         sx={{
           height: '50vh',

--- a/frontend/src/resources/constants.js
+++ b/frontend/src/resources/constants.js
@@ -1,6 +1,6 @@
 export const appTitle = 'OUR SEARCH'
 
-export const errorLoadingPostingsMessage = 'Internal server error. Error loading site data.'
+export const errorLoadingPostingsMessage = 'Sorry, there was an error loading site data. Try again later.'
 export const noPostsMessage = 'None available'
 
 export const viewStudentsFlag = 'students'


### PR DESCRIPTION
# Overview

**Type of Change:** Other

**Summary:** Changed the endpoints to delete current student and faculty profiles to cause logout. Did this by changing a successful response to instead redirect to the logout URL on the backend, which triggers full logout process to avoid caching the user and removing all memory of authentication. I added messages to display on the frontend if the request fails.

## UI/UX Implementation
Error messages on the landing page of the frontend

## Model Updates
None

### Data Models
None

### Object-Oriented Models
 None

## End-to-End Testing Instructions
1. you wont see the error messages display on the frontend unless you intentionally don't run the backend (since right now the backend is working)