### PR TITLE
Logout / delete profile bug fix

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -14,7 +14,6 @@ package COMP_49X_our_search.backend.gateway;
 
 import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoFacultyToFacultyDto;
 import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoStudentToStudentDto;
-
 import COMP_49X_our_search.backend.authentication.OAuthChecker;
 import COMP_49X_our_search.backend.gateway.dto.CreateFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.CreateStudentRequestDTO;
@@ -33,12 +32,17 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import COMP_49X_our_search.backend.security.LogoutService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -81,16 +85,17 @@ public class GatewayController {
   private final ResearchPeriodService researchPeriodService;
   private final DisciplineService disciplineService;
   private final UmbrellaTopicService umbrellaTopicService;
+  private final LogoutService logoutService;
 
   @Autowired
   public GatewayController(
-      ModuleInvoker moduleInvoker,
-      OAuthChecker oAuthChecker,
-      DepartmentService departmentService,
-      MajorService majorService,
-      ResearchPeriodService researchPeriodService,
-      UmbrellaTopicService umbrellaTopicService,
-      DisciplineService disciplineService) {
+          ModuleInvoker moduleInvoker,
+          OAuthChecker oAuthChecker,
+          DepartmentService departmentService,
+          MajorService majorService,
+          ResearchPeriodService researchPeriodService,
+          UmbrellaTopicService umbrellaTopicService,
+          DisciplineService disciplineService, LogoutService logoutService) {
     this.moduleInvoker = moduleInvoker;
     this.oAuthChecker = oAuthChecker;
     this.departmentService = departmentService;
@@ -98,6 +103,7 @@ public class GatewayController {
     this.researchPeriodService = researchPeriodService;
     this.disciplineService = disciplineService;
     this.umbrellaTopicService = umbrellaTopicService;
+    this.logoutService = logoutService;
   }
 
   @GetMapping("/projects")
@@ -304,7 +310,7 @@ public class GatewayController {
     String[] nameParts = splitFullName(requestBody.getName());
     String firstName = nameParts[0];
     String lastName = nameParts[1];
-    boolean hasPriorExperience = requestBody.getHasPriorExperience().equals("yes");
+    boolean hasPriorExperience = requestBody.getHasPriorExperience();
 
     ModuleConfig moduleConfig =
         ModuleConfig.newBuilder()
@@ -339,7 +345,7 @@ public class GatewayController {
   }
 
   @DeleteMapping("/api/studentProfiles/current")
-  public ResponseEntity<Void> deleteStudentProfile(HttpServletResponse res) throws IOException {
+  public ResponseEntity<Void> deleteStudentProfile(HttpServletRequest req, HttpServletResponse res) throws IOException {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     ModuleConfig moduleConfig =
         ModuleConfig.newBuilder()
@@ -353,9 +359,9 @@ public class GatewayController {
     DeleteProfileResponse deleteProfileResponse =
         response.getProfileResponse().getDeleteProfileResponse();
     if (deleteProfileResponse.getSuccess()) {
-      // Redirect user to the logout endpoint
-      res.sendRedirect("/logout");
-      return null; // Response is already handled by the redirection
+      if (logoutService.logoutCurrentUser(req, res, authentication)) {
+        return ResponseEntity.ok().build();
+      }
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }
@@ -439,7 +445,7 @@ public class GatewayController {
   }
 
   @DeleteMapping("/api/facultyProfiles/current")
-  public ResponseEntity<Void> deleteFacultyProfile(HttpServletResponse res) throws IOException {
+  public ResponseEntity<Void> deleteFacultyProfile(HttpServletRequest req, HttpServletResponse res) throws IOException {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     ModuleConfig moduleConfig =
         ModuleConfig.newBuilder()
@@ -453,9 +459,9 @@ public class GatewayController {
     DeleteProfileResponse deleteProfileResponse =
         response.getProfileResponse().getDeleteProfileResponse();
     if (deleteProfileResponse.getSuccess()) {
-      // Redirect user to the logout endpoint
-      res.sendRedirect("/logout");
-      return null; // Response is already handled by the redirection
+      if (logoutService.logoutCurrentUser(req, res, authentication)) {
+        return ResponseEntity.ok().build();
+      }
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
   }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/EditStudentRequestDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/EditStudentRequestDTO.java
@@ -7,7 +7,7 @@ public class EditStudentRequestDTO {
   private String name;
   private String classStatus;
   private String graduationYear;
-  private String hasPriorExperience;
+  private boolean hasPriorExperience;
   private boolean active;
   private String interestReason;
   private List<String> majors;
@@ -20,7 +20,7 @@ public class EditStudentRequestDTO {
       String name,
       String classStatus,
       String graduationYear,
-      String hasPriorExperience,
+      boolean hasPriorExperience,
       boolean active,
       String interestReason,
       List<String> majors,
@@ -62,11 +62,11 @@ public class EditStudentRequestDTO {
     this.graduationYear = graduationYear;
   }
 
-  public String getHasPriorExperience() {
+  public boolean getHasPriorExperience() {
     return hasPriorExperience;
   }
 
-  public void setHasPriorExperience(String hasPriorExperience) {
+  public void setHasPriorExperience(boolean hasPriorExperience) {
     this.hasPriorExperience = hasPriorExperience;
   }
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/LogoutHandler.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/LogoutHandler.java
@@ -1,0 +1,9 @@
+package COMP_49X_our_search.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+public interface LogoutHandler {
+    boolean logoutCurrentUser(HttpServletRequest req, HttpServletResponse res, Authentication authentication);
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/security/LogoutService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/security/LogoutService.java
@@ -1,0 +1,29 @@
+package COMP_49X_our_search.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LogoutService implements LogoutHandler {
+    @Override
+    public boolean logoutCurrentUser(HttpServletRequest req, HttpServletResponse res, Authentication authentication) {
+        try {
+            SecurityContextLogoutHandler logoutHandler = new SecurityContextLogoutHandler();
+            logoutHandler.logout(req, res, authentication);
+            SecurityContextHolder.clearContext(); // clears the Authentication information saved by Spring Security's SecurityContextHolder
+            req.getSession().invalidate();
+            new CookieClearingLogoutHandler(AbstractRememberMeServices.SPRING_SECURITY_REMEMBER_ME_COOKIE_KEY).logout(req, res, authentication);
+            return true;
+        } catch (Exception e) {
+            System.out.println("log out failed");
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1,17 +1,14 @@
 package COMP_49X_our_search.backend.gateway;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-import COMP_49X_our_search.backend.database.MajorServiceTest;
 import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Major;
@@ -31,17 +28,27 @@ import COMP_49X_our_search.backend.gateway.dto.EditStudentRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.MajorDTO;
 import COMP_49X_our_search.backend.gateway.dto.ResearchPeriodDTO;
 import COMP_49X_our_search.backend.gateway.dto.UmbrellaTopicDTO;
+import COMP_49X_our_search.backend.security.LogoutService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import proto.core.Core.ModuleConfig;
@@ -81,6 +88,10 @@ public class GatewayControllerTest {
   @MockBean private MajorService majorService;
   @MockBean private UmbrellaTopicService umbrellaTopicService;
   @MockBean private DisciplineService disciplineService;
+  @MockBean private LogoutService logoutService;
+  @MockBean private Authentication authentication;
+  @MockBean private HttpSession session;
+  @MockBean private SecurityContextHolderAwareRequestWrapper requestWrapper;
 
   @BeforeEach
   void setUp() {
@@ -461,7 +472,7 @@ public class GatewayControllerTest {
     requestDTO.setName("UpdatedFirst UpdatedLast");
     requestDTO.setClassStatus("Senior");
     requestDTO.setGraduationYear("2025");
-    requestDTO.setHasPriorExperience("yes");
+    requestDTO.setHasPriorExperience(true);
     requestDTO.setActive(true);
     requestDTO.setInterestReason("New reason");
     requestDTO.setMajors(List.of("Computer Science"));
@@ -589,15 +600,37 @@ public class GatewayControllerTest {
 
     when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
 
+    requestWrapper = mock(SecurityContextHolderAwareRequestWrapper.class);
+    when(requestWrapper.getSession()).thenReturn(session);
+    when(requestWrapper.isUserInRole(anyString())).thenReturn(true);
+    authentication = new UsernamePasswordAuthenticationToken(
+            new org.springframework.security.core.userdetails.User(
+                    "user",
+                    "password",
+                    AuthorityUtils.createAuthorityList("ROLE_USER")),
+            "password",
+            AuthorityUtils.createAuthorityList("ROLE_USER")
+    );
+
+    when(logoutService.logoutCurrentUser(
+            any(SecurityContextHolderAwareRequestWrapper.class),
+            any(HttpServletResponse.class),
+            eq(authentication)))
+            .thenReturn(true);
+
     mockMvc
         .perform(delete("/api/facultyProfiles/current"))
-            .andExpect(status().is3xxRedirection()) // Assert redirection status
-            .andExpect(header().string("Location", "/logout"));
+            .andExpect(status().isOk());
 
     mockMvc
             .perform(delete("/api/studentProfiles/current"))
-            .andExpect(status().is3xxRedirection()) // Assert redirection status
-            .andExpect(header().string("Location", "/logout"));
+            .andExpect(status().isOk());
+
+    verify(logoutService, times(2)).logoutCurrentUser(
+            any(SecurityContextHolderAwareRequestWrapper.class),
+            any(HttpServletResponse.class),
+            eq(authentication)
+    );
   }
 
   @Test

--- a/backend/src/test/java/COMP_49X_our_search/backend/security/LogoutServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/security/LogoutServiceTest.java
@@ -1,0 +1,53 @@
+package COMP_49X_our_search.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.Authentication;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogoutServiceTest {
+
+    private LogoutService logoutService;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private Authentication authentication;
+    @Mock
+    private HttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        logoutService = new LogoutService();
+
+        when(request.getSession()).thenReturn(session);
+    }
+
+    @Test
+    void logoutCurrentUser_Success() {
+        boolean result = logoutService.logoutCurrentUser(request, response, authentication);
+
+        assertTrue(result, "Logout should be successful");
+
+        verify(request, times(1)).getSession();
+        verify(session, times(1)).invalidate();
+    }
+
+    @Test
+    void logoutCurrentUser_Exception() {
+        doThrow(new RuntimeException("Session error")).when(session).invalidate();
+
+        boolean result = logoutService.logoutCurrentUser(request, response, authentication);
+
+        assertFalse(result, "Logout should fail due to exception");
+    }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -90,15 +90,8 @@ function App () {
       setIsFaculty(false)
       setIsAdmin(false)
 
-      const response = await fetch(`${backendUrl}/logout`, {
-        credentials: 'include',
-        method: 'POST',
-        redirect: 'follow'
-      })
+      window.location.href = backendUrl + '/'
 
-      if (!response.ok) {
-        throw new Error('Error logging out')
-      }
     } catch (error) {
       console.error(error)
       setLogoutError(true)

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -90,8 +90,7 @@ function App () {
       setIsFaculty(false)
       setIsAdmin(false)
 
-      window.location.href = backendUrl + '/'
-
+      window.location.href = backendUrl + '/logout'
     } catch (error) {
       console.error(error)
       setLogoutError(true)

--- a/frontend/src/__tests__/profiles/StudentProfileEdit.test.js
+++ b/frontend/src/__tests__/profiles/StudentProfileEdit.test.js
@@ -146,15 +146,11 @@ describe('StudentProfileEdit', () => {
     expect(screen.getByDisplayValue(getStudentCurrentExpected.researchPeriodsInterest.join(', '))).toBeInTheDocument()
 
     // Verify Prior Research Experience radio group: radio with label "Yes" should be checked
-    if (getStudentCurrentExpected.hasPriorExperience) {
-      expect(screen.getByRole('radio', { name: /Yes/i })).toBeChecked()
-    } else {
-      expect(screen.getByRole('radio', { name: /No/i })).toBeChecked()
-    }
+    expect(screen.getByRole('radio', { name: /Yes/i })).toBeChecked()
 
-    // The "Set Profile as Inactive" checkbox should be unchecked when active is true
-    const inactiveCheckbox = screen.getByRole('checkbox', { name: /Set Profile as Inactive/i })
-    expect(inactiveCheckbox).not.toBeChecked()
+    // The "Profile Status - Inactive" should be NOT checked because active is true for the mock student
+    const inactiveRadio = screen.getByLabelText(/Inactive/i)
+    expect(inactiveRadio).not.toBeChecked()
   })
 
   it('submits updated profile successfully and shows success message', async () => {
@@ -167,9 +163,10 @@ describe('StudentProfileEdit', () => {
     await userEvent.type(nameInput, 'Jane Smith')
 
     // Toggle inactive checkbox to set profile as inactive
-    const inactiveCheckbox = screen.getByRole('checkbox', { name: /Set Profile as Inactive/i })
-    await userEvent.click(inactiveCheckbox)
-    expect(inactiveCheckbox).toBeChecked()
+    // Select "Inactive" radio button to set profile as inactive
+    const inactiveRadio = screen.getByLabelText(/Inactive/i) // Use label to target specific radio
+    await userEvent.click(inactiveRadio)
+    expect(inactiveRadio).toBeChecked()
 
     // Submit the form
     const submitButton = screen.getByRole('button', { name: /Submit/i })

--- a/frontend/src/components/profiles/FacultyProfileView.js
+++ b/frontend/src/components/profiles/FacultyProfileView.js
@@ -73,7 +73,8 @@ const FacultyProfileView = () => {
       if (!response.ok) {
         throw new Error('Failed to delete profile')
       }
-      navigate('/') // go back to login/landing screen
+      // navigate('/') // go back to login/landing screen
+      window.location.href = backendUrl + '/logout'  // log out of google entirely
     } catch (err) {
       setError('Failed to delete profile. Please try again.')
     }

--- a/frontend/src/components/profiles/FacultyProfileView.js
+++ b/frontend/src/components/profiles/FacultyProfileView.js
@@ -72,9 +72,9 @@ const FacultyProfileView = () => {
       })
       if (!response.ok) {
         throw new Error('Failed to delete profile')
+      } else {
+        window.location.href = backendUrl + '/logout' // log out of google entirely
       }
-      // navigate('/') // go back to login/landing screen
-      window.location.href = backendUrl + '/logout'  // log out of google entirely
     } catch (err) {
       setError('Failed to delete profile. Please try again.')
     }

--- a/frontend/src/components/profiles/StudentProfileEdit.js
+++ b/frontend/src/components/profiles/StudentProfileEdit.js
@@ -76,7 +76,7 @@ const StudentProfileEdit = () => {
             researchPeriodsInterest: data.researchPeriodsInterest || [],
             interestReason: data.interestReason || '',
             hasPriorExperience: data.hasPriorExperience,
-            active: data.active !== undefined ? data.active : true
+            active: data.isActive
           })
         }
       } catch (error) {
@@ -299,16 +299,18 @@ const StudentProfileEdit = () => {
             <FormControlLabel value='false' control={<Radio />} label='No' />
           </RadioGroup>
         </FormControl>
-        <FormControlLabel
-          control={
-            <Checkbox
-              checked={!formData.active}
-              onChange={handleChange}
-              name='active'
-            />
-          }
-          label='Set Profile as Inactive'
-        />
+        <FormControl component='fieldset' required>
+          <Typography variant='subtitle1'>Profile Status</Typography>
+          <RadioGroup
+            row
+            name='active'
+            value={formData.active ? 'true' : 'false'}
+            onChange={handleChange}
+          >
+            <FormControlLabel value='true' control={<Radio />} label='Active' />
+            <FormControlLabel value='false' control={<Radio />} label='Inactive' />
+          </RadioGroup>
+        </FormControl>
         <Button onClick={handleReset} variant='contained' color='error' type='button' disabled={submitLoading}>
           Reset
         </Button>

--- a/frontend/src/components/profiles/StudentProfileEdit.js
+++ b/frontend/src/components/profiles/StudentProfileEdit.js
@@ -37,7 +37,7 @@ const StudentProfileEdit = () => {
     researchFieldInterests: [],
     researchPeriodsInterest: [],
     interestReason: '',
-    hasPriorExperience: '',
+    hasPriorExperience: false, // must be a boolean
     active: true // true means active; false means inactive
   })
   const [loading, setLoading] = useState(true)
@@ -75,7 +75,7 @@ const StudentProfileEdit = () => {
             researchFieldInterests: data.researchFieldInterests || [],
             researchPeriodsInterest: data.researchPeriodsInterest || [],
             interestReason: data.interestReason || '',
-            hasPriorExperience: data.hasPriorExperience || '',
+            hasPriorExperience: data.hasPriorExperience,
             active: data.active !== undefined ? data.active : true
           })
         }
@@ -102,12 +102,16 @@ const StudentProfileEdit = () => {
 
   const handleChange = (event) => {
     const { name, value, type, checked } = event.target
-    if (type === 'checkbox') {
-      // For the inactive checkbox, if checked means "Set Profile as Inactive", then active = !checked.
-      setFormData(prev => ({ ...prev, [name]: !checked }))
-    } else {
-      setFormData(prev => ({ ...prev, [name]: value }))
-    }
+    setFormData(prev => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value === 'true' ? true : value === 'false' ? false : value
+    }))
+    // if (type === 'checkbox') {
+    //   // For the inactive checkbox, if checked means "Set Profile as Inactive", then active = !checked.
+    //   setFormData(prev => ({ ...prev, [name]: type === 'checkbox' ? !checked : value === "true" }))
+    // } else {
+    //   setFormData(prev => ({ ...prev, [name]: value }))
+    // }
   }
 
   const handleMultiSelectChange = (event, fieldName) => {
@@ -133,7 +137,8 @@ const StudentProfileEdit = () => {
       // Ensure classStatus is converted from array to a single string value
       const updatedFormData = {
         ...formData,
-        classStatus: formData.classStatus[0] || '' // Convert to string or empty string if no value selected
+        hasPriorExperience: Boolean(formData.hasPriorExperience),
+        classStatus: formData.classStatus || '' // Convert to string or empty string if no value selected
       }
       const response = await fetch(`${backendUrl}/api/studentProfiles/current`, {
         method: 'PUT',
@@ -204,7 +209,7 @@ const StudentProfileEdit = () => {
             labelId='class-status-label'
             name='classStatus'
             value={formData.classStatus}
-            onChange={(e) => handleMultiSelectChange(e, 'classStatus')}
+            onChange={handleChange}
             input={<OutlinedInput label='Class Status' />}
             renderValue={(selected) => selected || ''}
           >
@@ -287,11 +292,11 @@ const StudentProfileEdit = () => {
           <RadioGroup
             row
             name='hasPriorExperience'
-            value={formData.hasPriorExperience ? 'yes' : 'no'}
+            value={formData.hasPriorExperience ? 'true' : 'false'}
             onChange={handleChange}
           >
-            <FormControlLabel value='yes' control={<Radio />} label='Yes' />
-            <FormControlLabel value='no' control={<Radio />} label='No' />
+            <FormControlLabel value='true' control={<Radio />} label='Yes' />
+            <FormControlLabel value='false' control={<Radio />} label='No' />
           </RadioGroup>
         </FormControl>
         <FormControlLabel

--- a/frontend/src/components/profiles/StudentProfileEdit.js
+++ b/frontend/src/components/profiles/StudentProfileEdit.js
@@ -12,7 +12,7 @@
 
 import React, { useState, useEffect } from 'react'
 import {
-  Box, Button, TextField, Typography, Paper, CircularProgress, Checkbox,
+  Box, Button, TextField, Typography, Paper, CircularProgress,
   FormControlLabel, FormControl, InputLabel, Select, OutlinedInput, MenuItem,
   Chip, RadioGroup, Radio
 } from '@mui/material'

--- a/frontend/src/components/profiles/StudentProfileView.js
+++ b/frontend/src/components/profiles/StudentProfileView.js
@@ -71,8 +71,9 @@ const StudentProfileView = () => {
       })
       if (!response.ok) {
         throw new Error('Failed to delete profile')
+      } else {
+        window.location.href = backendUrl + '/logout' // log out of google entirely
       }
-      window.location.href = backendUrl + '/logout'  // log out of google entirely
     } catch (err) {
       setError('Failed to delete profile. Please try again.')
     }

--- a/frontend/src/components/profiles/StudentProfileView.js
+++ b/frontend/src/components/profiles/StudentProfileView.js
@@ -72,7 +72,7 @@ const StudentProfileView = () => {
       if (!response.ok) {
         throw new Error('Failed to delete profile')
       }
-      navigate('/')
+      window.location.href = backendUrl + '/logout'  // log out of google entirely
     } catch (err) {
       setError('Failed to delete profile. Please try again.')
     }

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -341,7 +341,7 @@ export const putStudentCurrentExpected = {
   researchFieldInterests: ['Computer Science', 'Data Science'],
   researchPeriodsInterest: ['Fall 2024'],
   interestReason: 'I want to gain research experience.',
-  hasPriorExperience: 'yes',
+  hasPriorExperience: true,
   active: false
 }
 

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -329,7 +329,7 @@ export const getStudentCurrentExpected = {
   researchPeriodsInterest: ['Fall 2024'],
   interestReason: 'I want to gain research experience.',
   hasPriorExperience: true,
-  active: true
+  isActive: true
 }
 
 // expected request to PUT /studentProfiles/current


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** There was an error with how I had implemented logging out previously due to CORS policies (the frontend, backend, and google URLs are configured in a way that only works in a certain way so that only certain origins can communicate in certain orders). Implemented a new LogoutService on the backend to use to effective log the user out when they delete their profile or try to sign in with the correct @sandiego email address. Fixed bugs on the frontend so that it is handled correctly when the user clicks logout, tries to sign in with the wrong email domain, or deletes their profile. 

## UI/UX Implementation
No changes

## Model Updates
GatewayController and OauthSuccessHandler now use Logout Service via dependency injection.

### Data Models
No changes

### Object-Oriented Models
- New LogoutHandler interface requiring a method called logoutCurrentUser.
- New LogoutService that implements LogoutHandler.

## End-to-End Testing Instructions
The following features now work correctly:
1. login and logout. Successfully logs you out of the backend app and google.
3. login, create profile, and delete profile. Successfully logs you out of the backend app, logs you out of google,  and deletes your profile. 