### PR TITLE
Implement retrieve grouped faculty endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FacultyRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FacultyRepository.java
@@ -9,6 +9,7 @@
 package COMP_49X_our_search.backend.database.repositories;
 
 import COMP_49X_our_search.backend.database.entities.Faculty;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -16,4 +17,5 @@ public interface FacultyRepository extends JpaRepository<Faculty, Integer> {
   boolean existsByEmail(String email);
   Optional<Faculty> findFacultyByEmail(String email);
   void deleteByEmail(String email);
+  List<Faculty> findAllByDepartments_Id(Integer departmentId);
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/FacultyService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/FacultyService.java
@@ -10,6 +10,7 @@ package COMP_49X_our_search.backend.database.services;
 
 import COMP_49X_our_search.backend.database.entities.Faculty;
 import COMP_49X_our_search.backend.database.repositories.FacultyRepository;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -43,5 +44,9 @@ public class FacultyService {
           String.format("Cannot delete faculty with email '%s'. Faculty not found.", email));
     }
     facultyRepository.deleteByEmail(email);
+  }
+
+  public List<Faculty> getFacultyByDepartmentId(Integer departmentId) {
+    return facultyRepository.findAllByDepartments_Id(departmentId);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/fetcher/FacultyFetcher.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/fetcher/FacultyFetcher.java
@@ -1,0 +1,94 @@
+package COMP_49X_our_search.backend.fetcher;
+
+import COMP_49X_our_search.backend.database.entities.Department;
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.entities.Project;
+import COMP_49X_our_search.backend.database.services.DepartmentService;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.ProjectService;
+import COMP_49X_our_search.backend.util.ProtoConverter;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import proto.fetcher.DataTypes.DepartmentHierarchy;
+import proto.fetcher.DataTypes.DepartmentWithFaculty;
+import proto.fetcher.DataTypes.FacultyWithProjects;
+import proto.fetcher.FetcherModule.FetcherRequest;
+import proto.fetcher.FetcherModule.FetcherRequest.FetcherTypeCase;
+import proto.fetcher.FetcherModule.FetcherResponse;
+import proto.fetcher.FetcherModule.FilteredType;
+
+@Service
+public class FacultyFetcher implements Fetcher {
+
+  private final DepartmentService departmentService;
+  private final FacultyService facultyService;
+  private final ProjectService projectService;
+
+  @Autowired
+  public FacultyFetcher(
+      DepartmentService departmentService,
+      FacultyService facultyService,
+      ProjectService projectService) {
+    this.departmentService = departmentService;
+    this.facultyService = facultyService;
+    this.projectService = projectService;
+  }
+
+  @Override
+  public FetcherResponse fetch(FetcherRequest request) {
+    validateRequest(request);
+    List<Department> departments = departmentService.getAllDepartments();
+
+    List<DepartmentWithFaculty> departmentsWithFacultyProto =
+        departments.stream().map(this::buildDepartmentWithFaculty).toList();
+
+    return FetcherResponse.newBuilder()
+        .setDepartmentHierarchy(
+            DepartmentHierarchy.newBuilder().addAllDepartments(departmentsWithFacultyProto).build())
+        .build();
+  }
+
+  private DepartmentWithFaculty buildDepartmentWithFaculty(Department department) {
+    List<Faculty> facultyMembers = facultyService.getFacultyByDepartmentId(department.getId());
+
+    DepartmentWithFaculty.Builder departmentBuilder =
+        DepartmentWithFaculty.newBuilder()
+            .setDepartment(ProtoConverter.toDepartmentProto(department));
+
+    facultyMembers.forEach(
+        faculty -> {
+          List<Project> projects = projectService.getProjectsByFacultyId(faculty.getId());
+
+          FacultyWithProjects facultyWithProjects =
+              FacultyWithProjects.newBuilder()
+                  .setFaculty(ProtoConverter.toFacultyProto(faculty))
+                  .addAllProjects(projects.stream().map(ProtoConverter::toProjectProto).toList())
+                  .build();
+
+          departmentBuilder.addFacultyWithProjects(facultyWithProjects);
+        });
+
+    return departmentBuilder.build();
+  }
+
+  private void validateRequest(FetcherRequest request) {
+    if (request.getFetcherTypeCase() == FetcherTypeCase.FETCHERTYPE_NOT_SET) {
+      throw new IllegalArgumentException(
+          "Expected fetcher_type to be set, but no fetcher type was provided. Valid types: filtered_fetcher");
+    }
+    if (request.getFetcherTypeCase() != FetcherTypeCase.FILTERED_FETCHER) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected fetcher_type 'filtered_fetcher', but got '%s'",
+              request.getFetcherTypeCase().toString().toLowerCase()));
+    }
+    if (request.getFilteredFetcher().getFilteredType() != FilteredType.FILTERED_TYPE_FACULTY) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected filtered_type '%s', but got '%s'",
+              FilteredType.FILTERED_TYPE_FACULTY,
+              request.getFilteredFetcher().getFilteredType().toString()));
+    }
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/fetcher/FetcherModuleController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/fetcher/FetcherModuleController.java
@@ -41,10 +41,11 @@ public class FetcherModuleController implements ModuleController {
   private final DisciplineFetcher disciplineFetcher;
   private final ProjectFetcher projectFetcher;
   private final StudentFetcher studentFetcher;
+  private final FacultyFetcher facultyFetcher;
 
   @Autowired
   public FetcherModuleController(DisciplineFetcher disciplineFetcher,
-      ProjectFetcher projectFetcher, StudentFetcher studentFetcher) {
+      ProjectFetcher projectFetcher, StudentFetcher studentFetcher, FacultyFetcher facultyFetcher) {
     // Initialize EnumMaps for mapping fetcher types to fetcher implementations
     this.directTypeFetcherMap = new EnumMap<>(DirectType.class);
     this.filteredTypeFetcherMap = new EnumMap<>(FilteredType.class);
@@ -52,6 +53,7 @@ public class FetcherModuleController implements ModuleController {
     this.disciplineFetcher = disciplineFetcher;
     this.projectFetcher = projectFetcher;
     this.studentFetcher = studentFetcher;
+    this.facultyFetcher = facultyFetcher;
 
     // Map DirectType values to the appropriate fetcher implementation
     directTypeFetcherMap.put(DirectType.DIRECT_TYPE_DISCIPLINES, disciplineFetcher);
@@ -59,6 +61,7 @@ public class FetcherModuleController implements ModuleController {
     // Map FilteredType values to the appropriate fetcher implementations
     filteredTypeFetcherMap.put(FilteredType.FILTERED_TYPE_PROJECTS, projectFetcher);
     filteredTypeFetcherMap.put(FilteredType.FILTERED_TYPE_STUDENTS, studentFetcher);
+    filteredTypeFetcherMap.put(FilteredType.FILTERED_TYPE_FACULTY, facultyFetcher);
   }
 
   @Override

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/DepartmentDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/DepartmentDTO.java
@@ -7,13 +7,15 @@ public class DepartmentDTO {
   private int id;
   private String name;
   private List<MajorDTO> majors;
+  private List<FacultyDTO> faculty;
 
   public DepartmentDTO() {}
 
-  public DepartmentDTO(int id, String name, List<MajorDTO> majors) {
+  public DepartmentDTO(int id, String name, List<MajorDTO> majors, List<FacultyDTO> faculty) {
     this.id = id;
     this.name = name;
     this.majors = majors;
+    this.faculty = faculty;
   }
 
   public int getId() {
@@ -38,5 +40,13 @@ public class DepartmentDTO {
 
   public void setMajors(List<MajorDTO> majors) {
     this.majors = majors;
+  }
+
+  public List<FacultyDTO> getFaculty() {
+    return faculty;
+  }
+
+  public void setFaculty(List<FacultyDTO> faculty) {
+    this.faculty = faculty;
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FacultyDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FacultyDTO.java
@@ -3,12 +3,22 @@ package COMP_49X_our_search.backend.gateway.dto;
 import java.util.List;
 
 public class FacultyDTO {
+  private int id;
   private String firstName;
   private String lastName;
   private String email;
   private List<String> department;
+  private List<ProjectDTO> projects;
 
   public FacultyDTO() {}
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
 
   public String getFirstName() {
     return firstName;
@@ -40,5 +50,13 @@ public class FacultyDTO {
 
   public void setDepartment(List<String> department) {
     this.department = department;
+  }
+
+  public List<ProjectDTO> getProjects() {
+    return projects;
+  }
+
+  public void setProjects(List<ProjectDTO> projects) {
+    this.projects = projects;
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
@@ -1,11 +1,11 @@
 /**
- * Utility class for converting Protobuf project hierarchy data into DTOs for
- * use in the frontend.
+ * Utility class for converting Protobuf project hierarchy data into DTOs for use in the frontend.
  *
  * @author Augusto Escudero
  */
 package COMP_49X_our_search.backend.gateway.util;
 
+import COMP_49X_our_search.backend.gateway.dto.DepartmentDTO;
 import COMP_49X_our_search.backend.gateway.dto.DisciplineDTO;
 import COMP_49X_our_search.backend.gateway.dto.FacultyDTO;
 import COMP_49X_our_search.backend.gateway.dto.MajorDTO;
@@ -13,11 +13,14 @@ import COMP_49X_our_search.backend.gateway.dto.ProjectDTO;
 import COMP_49X_our_search.backend.gateway.dto.ProjectHierarchyDTO;
 import COMP_49X_our_search.backend.gateway.dto.StudentDTO;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
+import proto.data.Entities.DepartmentProto;
 import proto.data.Entities.FacultyProto;
 import proto.data.Entities.ProjectProto;
 import proto.data.Entities.StudentProto;
+import proto.fetcher.DataTypes.DepartmentWithFaculty;
 import proto.fetcher.DataTypes.DisciplineWithMajors;
 import proto.fetcher.DataTypes.MajorWithEntityCollection;
 import proto.fetcher.DataTypes.ProjectHierarchy;
@@ -29,31 +32,84 @@ public final class ProjectHierarchyConverter {
 
   // TODO(@acescudero): Unused for now, /projects response format expects a list
   // of DepartmentDTO.
-  private static ProjectHierarchyDTO protoProjectHierarchyToDto(
-      ProjectHierarchy proto) {
+  private static ProjectHierarchyDTO protoProjectHierarchyToDto(ProjectHierarchy proto) {
     ProjectHierarchyDTO dto = new ProjectHierarchyDTO();
-    dto.setDisciplines(proto.getDisciplinesList().stream()
-        .map(ProjectHierarchyConverter::protoDisciplineWithMajorsToDto)
-        .collect(Collectors.toList()));
+    dto.setDisciplines(
+        proto.getDisciplinesList().stream()
+            .map(ProjectHierarchyConverter::protoDisciplineWithMajorsToDto)
+            .collect(Collectors.toList()));
     return dto;
   }
 
-  public static DisciplineDTO protoDisciplineWithMajorsToDto(
-      DisciplineWithMajors proto) {
+  public static DisciplineDTO protoDisciplineWithMajorsToDto(DisciplineWithMajors proto) {
     DisciplineDTO dto = new DisciplineDTO();
     dto.setId(proto.getDiscipline().getDisciplineId());
     dto.setName(proto.getDiscipline().getDisciplineName());
     if (proto.getMajorsList().getFirst().hasProjectCollection()) { // Has Project collection
-      dto.setMajors(proto.getMajorsList().stream()
-          .map(ProjectHierarchyConverter::protoMajorWithProjectsToMajorDto)
-          .collect(Collectors.toList()));
+      dto.setMajors(
+          proto.getMajorsList().stream()
+              .map(ProjectHierarchyConverter::protoMajorWithProjectsToMajorDto)
+              .collect(Collectors.toList()));
       return dto;
     } else { // Has StudentCollection
-      dto.setMajors(proto.getMajorsList().stream()
-          .map(ProjectHierarchyConverter::protoMajorWithStudentsToMajorDto)
-          .collect(Collectors.toList()));
+      dto.setMajors(
+          proto.getMajorsList().stream()
+              .map(ProjectHierarchyConverter::protoMajorWithStudentsToMajorDto)
+              .collect(Collectors.toList()));
       return dto;
     }
+  }
+
+  public static DepartmentDTO protoDepartmentWithFacultyToDto(
+      DepartmentWithFaculty departmentWithFacultyProto) {
+    DepartmentDTO departmentDTO = new DepartmentDTO();
+    departmentDTO.setId(departmentWithFacultyProto.getDepartment().getDepartmentId());
+    departmentDTO.setName(departmentWithFacultyProto.getDepartment().getDepartmentName());
+
+    List<FacultyDTO> facultyDTOs =
+        departmentWithFacultyProto.getFacultyWithProjectsList().stream()
+            .map(
+                facultyWithProjects -> {
+                  FacultyDTO facultyDTO = new FacultyDTO();
+                  FacultyProto facultyProto = facultyWithProjects.getFaculty();
+
+                  facultyDTO.setId(facultyProto.getFacultyId());
+                  facultyDTO.setFirstName(facultyProto.getFirstName());
+                  facultyDTO.setLastName(facultyProto.getLastName());
+                  facultyDTO.setEmail(facultyProto.getEmail());
+                  facultyDTO.setDepartment(new ArrayList<>(facultyProto.getDepartmentsList()));
+
+                  List<ProjectDTO> projectDTOs =
+                      facultyWithProjects.getProjectsList().stream()
+                          .map(
+                              projectProto -> {
+                                ProjectDTO projectDTO = new ProjectDTO();
+                                projectDTO.setId(projectProto.getProjectId());
+                                projectDTO.setName(projectProto.getProjectName());
+                                projectDTO.setDescription(projectProto.getDescription());
+                                projectDTO.setDesiredQualifications(
+                                    projectProto.getDesiredQualifications());
+                                projectDTO.setIsActive(projectProto.getIsActive());
+                                projectDTO.setMajors(new ArrayList<>(projectProto.getMajorsList()));
+                                projectDTO.setUmbrellaTopics(
+                                    new ArrayList<>(projectProto.getUmbrellaTopicsList()));
+                                projectDTO.setResearchPeriods(
+                                    new ArrayList<>(projectProto.getResearchPeriodsList()));
+
+                                return projectDTO;
+                              })
+                          .collect(Collectors.toList());
+
+                  facultyDTO.setProjects(projectDTOs);
+                  return facultyDTO;
+                })
+            .collect(Collectors.toList());
+
+    departmentDTO.setFaculty(facultyDTOs);
+
+    departmentDTO.setMajors(new ArrayList<>());
+
+    return departmentDTO;
   }
 
   private static MajorDTO protoMajorWithStudentsToMajorDto(MajorWithEntityCollection proto) {
@@ -61,20 +117,21 @@ public final class ProjectHierarchyConverter {
     dto.setId(proto.getMajor().getMajorId());
     dto.setId(proto.getMajor().getMajorId());
     dto.setName(proto.getMajor().getMajorName());
-    dto.setPosts(proto.getStudentCollection().getStudentsList().stream()
-        .map(ProjectHierarchyConverter::protoStudentToStudentDto)
-        .collect(Collectors.toList()));
+    dto.setPosts(
+        proto.getStudentCollection().getStudentsList().stream()
+            .map(ProjectHierarchyConverter::protoStudentToStudentDto)
+            .collect(Collectors.toList()));
     return dto;
   }
 
-  private static MajorDTO protoMajorWithProjectsToMajorDto(
-      MajorWithEntityCollection proto) {
+  private static MajorDTO protoMajorWithProjectsToMajorDto(MajorWithEntityCollection proto) {
     MajorDTO dto = new MajorDTO();
     dto.setId(proto.getMajor().getMajorId());
     dto.setName(proto.getMajor().getMajorName());
-    dto.setPosts(proto.getProjectCollection().getProjectsList().stream()
-        .map(ProjectHierarchyConverter::protoProjectToProjectDto)
-        .collect(Collectors.toList()));
+    dto.setPosts(
+        proto.getProjectCollection().getProjectsList().stream()
+            .map(ProjectHierarchyConverter::protoProjectToProjectDto)
+            .collect(Collectors.toList()));
     return dto;
   }
 
@@ -94,6 +151,7 @@ public final class ProjectHierarchyConverter {
 
   public static FacultyDTO protoFacultyToFacultyDto(FacultyProto proto) {
     FacultyDTO dto = new FacultyDTO();
+    dto.setId(proto.getFacultyId());
     dto.setFirstName(proto.getFirstName());
     dto.setLastName(proto.getLastName());
     dto.setEmail(proto.getEmail());

--- a/backend/src/main/java/COMP_49X_our_search/backend/util/ProtoConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/util/ProtoConverter.java
@@ -82,12 +82,12 @@ public class ProtoConverter {
   }
 
   public static FacultyProto toFacultyProto(Faculty faculty) {
-    System.out.println(faculty.getDepartments());
     return FacultyProto.newBuilder()
         .setFirstName(faculty.getFirstName())
         .setLastName(faculty.getLastName())
         .setEmail(faculty.getEmail())
-        .addAllDepartments(faculty.getDepartments().stream().map(Department::getName).toList())
+        .addAllDepartments(faculty.getDepartments().stream().map(Department::getName).sorted().toList())
+        .setFacultyId(faculty.getId())
         .build();
   }
 

--- a/backend/src/main/proto/data/entities.proto
+++ b/backend/src/main/proto/data/entities.proto
@@ -34,6 +34,7 @@ message FacultyProto {
   string last_name = 2;
   string email = 3;
   repeated string departments = 4;
+  int32 faculty_id = 5;
 }
 
 message StudentProto {

--- a/backend/src/main/proto/fetcher/data_types.proto
+++ b/backend/src/main/proto/fetcher/data_types.proto
@@ -13,6 +13,10 @@ message ProjectHierarchy {
   repeated DisciplineWithMajors disciplines = 1;
 }
 
+message DepartmentHierarchy {
+  repeated DepartmentWithFaculty departments = 1;
+}
+
 // Helper structures
 
 message DisciplineWithMajors {
@@ -34,4 +38,14 @@ message ProjectCollection {
 
 message StudentCollection {
   repeated data.StudentProto students = 1;
+}
+
+message DepartmentWithFaculty {
+  data.DepartmentProto department = 1;
+  repeated FacultyWithProjects faculty_with_projects = 2;
+}
+
+message FacultyWithProjects {
+  data.FacultyProto faculty = 1;
+  repeated data.ProjectProto projects = 2;
 }

--- a/backend/src/main/proto/fetcher/fetcher_module.proto
+++ b/backend/src/main/proto/fetcher/fetcher_module.proto
@@ -15,7 +15,8 @@ message FetcherResponse {
   oneof fetched_data {
     DisciplineCollection discipline_collection = 1;
     ProjectHierarchy project_hierarchy = 2;
-    // Add more as more types are supported, e.g. students, projects, etc.
+    DepartmentHierarchy department_hierarchy = 3;
+    // Add more as more types are supported
   }
 }
 
@@ -38,5 +39,6 @@ enum FilteredType {
   FILTERED_TYPE_UNSPECIFIED = 0;
   FILTERED_TYPE_PROJECTS = 1;
   FILTERED_TYPE_STUDENTS = 2;
-  // Add more if needed, e.g. Students.
+  FILTERED_TYPE_FACULTY = 3;
+  // Add more if needed
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/FacultyServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/FacultyServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 import COMP_49X_our_search.backend.database.entities.Faculty;
 import COMP_49X_our_search.backend.database.repositories.FacultyRepository;
 import COMP_49X_our_search.backend.database.services.FacultyService;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -124,5 +125,31 @@ public class FacultyServiceTest {
 
     verify(facultyRepository, times(1)).existsByEmail(email);
     verify(facultyRepository, never()).deleteByEmail(email);
+  }
+
+  @Test
+  void testGetFacultyByDepartmentId_returnsFacultyList() {
+    Integer departmentId = 1;
+    Faculty faculty1 = new Faculty();
+    faculty1.setFirstName("John");
+    faculty1.setLastName("Doe");
+    faculty1.setEmail("jdoe@test.com");
+
+    Faculty faculty2 = new Faculty();
+    faculty2.setFirstName("Jane");
+    faculty2.setLastName("Smith");
+    faculty2.setEmail("jsmith@test.com");
+
+    List<Faculty> expectedFacultyList = List.of(faculty1, faculty2);
+
+    when(facultyRepository.findAllByDepartments_Id(departmentId)).thenReturn(expectedFacultyList);
+
+    List<Faculty> result = facultyService.getFacultyByDepartmentId(departmentId);
+
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertEquals(expectedFacultyList, result);
+
+    verify(facultyRepository, times(1)).findAllByDepartments_Id(departmentId);
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/fetcher/FacultyFetcherTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/fetcher/FacultyFetcherTest.java
@@ -1,0 +1,237 @@
+package COMP_49X_our_search.backend.fetcher;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import COMP_49X_our_search.backend.database.entities.Department;
+import COMP_49X_our_search.backend.database.entities.Faculty;
+import COMP_49X_our_search.backend.database.services.DepartmentService;
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.ProjectService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import proto.data.Entities.DepartmentProto;
+import proto.data.Entities.FacultyProto;
+import proto.fetcher.DataTypes.DepartmentHierarchy;
+import proto.fetcher.DataTypes.DepartmentWithFaculty;
+import proto.fetcher.DataTypes.FacultyWithProjects;
+import proto.fetcher.FetcherModule.FetcherRequest;
+import proto.fetcher.FetcherModule.FetcherResponse;
+import proto.fetcher.FetcherModule.FilteredFetcher;
+import proto.fetcher.FetcherModule.FilteredType;
+
+public class FacultyFetcherTest {
+  private FacultyFetcher facultyFetcher;
+  private DepartmentService departmentService;
+  private FacultyService facultyService;
+  private ProjectService projectService;
+
+  @BeforeEach
+  void setUp() {
+    departmentService = mock(DepartmentService.class);
+    facultyService = mock(FacultyService.class);
+    projectService = mock(ProjectService.class);
+    facultyFetcher = new FacultyFetcher(departmentService, facultyService, projectService);
+  }
+
+  @Test
+  public void testFetch_validRequest_returnsExpectedResponse() {
+    Department engineering = new Department("Engineering");
+    engineering.setId(1);
+    Department lifeAndPhysicalSciences = new Department("Life and Physical Sciences");
+    lifeAndPhysicalSciences.setId(2);
+
+    List<Department> departments = List.of(engineering, lifeAndPhysicalSciences);
+    when(departmentService.getAllDepartments()).thenReturn(departments);
+
+    Faculty engineeringFaculty = new Faculty();
+    engineeringFaculty.setId(1);
+    engineeringFaculty.setFirstName("John");
+    engineeringFaculty.setLastName("Smith");
+    engineeringFaculty.setEmail("jsmith@test.com");
+    engineeringFaculty.setDepartments(Set.of(engineering));
+
+    Faculty sciencesFaculty = new Faculty();
+    sciencesFaculty.setId(2);
+    sciencesFaculty.setFirstName("Jane");
+    sciencesFaculty.setLastName("Doe");
+    sciencesFaculty.setEmail("jdoe@test.com");
+    sciencesFaculty.setDepartments(Set.of(lifeAndPhysicalSciences));
+
+    when(facultyService.getFacultyByDepartmentId(engineering.getId()))
+        .thenReturn(List.of(engineeringFaculty));
+    when(facultyService.getFacultyByDepartmentId(lifeAndPhysicalSciences.getId()))
+        .thenReturn(List.of(sciencesFaculty));
+
+    when(projectService.getProjectsByFacultyId(engineeringFaculty.getId())).thenReturn(List.of());
+    when(projectService.getProjectsByFacultyId(sciencesFaculty.getId())).thenReturn(List.of());
+
+    FetcherRequest request =
+        FetcherRequest.newBuilder()
+            .setFilteredFetcher(
+                FilteredFetcher.newBuilder()
+                    .setFilteredType(FilteredType.FILTERED_TYPE_FACULTY)
+                    .build())
+            .build();
+
+    FacultyProto engineeringFacultyProto =
+        FacultyProto.newBuilder()
+            .setFacultyId(1)
+            .setFirstName("John")
+            .setLastName("Smith")
+            .setEmail("jsmith@test.com")
+            .addAllDepartments(List.of("Engineering"))
+            .build();
+
+    FacultyProto sciencesFacultyProto =
+        FacultyProto.newBuilder()
+            .setFacultyId(2)
+            .setFirstName("Jane")
+            .setLastName("Doe")
+            .setEmail("jdoe@test.com")
+            .addAllDepartments(List.of("Life and Physical Sciences"))
+            .build();
+
+    DepartmentProto engineeringProto =
+        DepartmentProto.newBuilder().setDepartmentId(1).setDepartmentName("Engineering").build();
+
+    DepartmentProto sciencesProto =
+        DepartmentProto.newBuilder()
+            .setDepartmentId(2)
+            .setDepartmentName("Life and Physical Sciences")
+            .build();
+
+    FacultyWithProjects engineeringFacultyWithProjects =
+        FacultyWithProjects.newBuilder().setFaculty(engineeringFacultyProto).build();
+
+    FacultyWithProjects sciencesFacultyWithProjects =
+        FacultyWithProjects.newBuilder().setFaculty(sciencesFacultyProto).build();
+
+    DepartmentWithFaculty engineeringWithFaculty =
+        DepartmentWithFaculty.newBuilder()
+            .setDepartment(engineeringProto)
+            .addFacultyWithProjects(engineeringFacultyWithProjects)
+            .build();
+
+    DepartmentWithFaculty sciencesWithFaculty =
+        DepartmentWithFaculty.newBuilder()
+            .setDepartment(sciencesProto)
+            .addFacultyWithProjects(sciencesFacultyWithProjects)
+            .build();
+
+    FetcherResponse expectedResponse =
+        FetcherResponse.newBuilder()
+            .setDepartmentHierarchy(
+                DepartmentHierarchy.newBuilder()
+                    .addDepartments(engineeringWithFaculty)
+                    .addDepartments(sciencesWithFaculty)
+                    .build())
+            .build();
+
+    FetcherResponse actualResponse = facultyFetcher.fetch(request);
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void testFetch_facultyInMultipleDepartments_returnsExpectedResponse() {
+    Department engineering = new Department("Engineering");
+    engineering.setId(1);
+    Department lifeAndPhysicalSciences = new Department("Life and Physical Sciences");
+    lifeAndPhysicalSciences.setId(2);
+
+    List<Department> departments = List.of(engineering, lifeAndPhysicalSciences);
+    when(departmentService.getAllDepartments()).thenReturn(departments);
+
+    Faculty multiDepartmentFaculty = new Faculty();
+    multiDepartmentFaculty.setId(1);
+    multiDepartmentFaculty.setFirstName("First");
+    multiDepartmentFaculty.setLastName("Last");
+    multiDepartmentFaculty.setEmail("flast@test.com");
+    multiDepartmentFaculty.setDepartments(Set.of(engineering, lifeAndPhysicalSciences));
+
+    when(facultyService.getFacultyByDepartmentId(engineering.getId()))
+        .thenReturn(List.of(multiDepartmentFaculty));
+    when(facultyService.getFacultyByDepartmentId(lifeAndPhysicalSciences.getId()))
+        .thenReturn(List.of(multiDepartmentFaculty));
+
+    when(projectService.getProjectsByFacultyId(multiDepartmentFaculty.getId()))
+        .thenReturn(List.of());
+
+    FetcherRequest request =
+        FetcherRequest.newBuilder()
+            .setFilteredFetcher(
+                FilteredFetcher.newBuilder()
+                    .setFilteredType(FilteredType.FILTERED_TYPE_FACULTY)
+                    .build())
+            .build();
+
+    FacultyProto expectedFacultyProto =
+        FacultyProto.newBuilder()
+            .setFacultyId(1)
+            .setFirstName("First")
+            .setLastName("Last")
+            .setEmail("flast@test.com")
+            .addAllDepartments(List.of("Engineering", "Life and Physical Sciences"))
+            .build();
+
+    FacultyWithProjects facultyWithProjects =
+        FacultyWithProjects.newBuilder().setFaculty(expectedFacultyProto).build();
+
+    DepartmentProto engineeringProto =
+        DepartmentProto.newBuilder().setDepartmentId(1).setDepartmentName("Engineering").build();
+
+    DepartmentProto sciencesProto =
+        DepartmentProto.newBuilder()
+            .setDepartmentId(2)
+            .setDepartmentName("Life and Physical Sciences")
+            .build();
+
+    DepartmentWithFaculty engineeringWithFaculty =
+        DepartmentWithFaculty.newBuilder()
+            .setDepartment(engineeringProto)
+            .addFacultyWithProjects(facultyWithProjects)
+            .build();
+
+    DepartmentWithFaculty sciencesWithFaculty =
+        DepartmentWithFaculty.newBuilder()
+            .setDepartment(sciencesProto)
+            .addFacultyWithProjects(facultyWithProjects)
+            .build();
+
+    FetcherResponse expectedResponse =
+        FetcherResponse.newBuilder()
+            .setDepartmentHierarchy(
+                DepartmentHierarchy.newBuilder()
+                    .addDepartments(engineeringWithFaculty)
+                    .addDepartments(sciencesWithFaculty)
+                    .build())
+            .build();
+
+    FetcherResponse actualResponse = facultyFetcher.fetch(request);
+
+    assertEquals(expectedResponse, actualResponse);
+  }
+
+  @Test
+  public void testFetch_missingFetcherType_throwsException() {
+    FetcherRequest invalidRequest = FetcherRequest.getDefaultInstance();
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              facultyFetcher.fetch(invalidRequest);
+            });
+
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Expected fetcher_type to be set, but no fetcher type was provided"));
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/fetcher/FetcherModuleControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/fetcher/FetcherModuleControllerTest.java
@@ -31,13 +31,15 @@ public class FetcherModuleControllerTest {
   private DisciplineFetcher disciplineFetcher;
   private ProjectFetcher projectFetcher;
   private StudentFetcher studentFetcher;
+  private FacultyFetcher facultyFetcher;
 
   @BeforeEach
   void setUp() {
     disciplineFetcher = mock(DisciplineFetcher.class);
     projectFetcher = mock(ProjectFetcher.class);
     studentFetcher = mock(StudentFetcher.class);
-    fetcherModuleController = new FetcherModuleController(disciplineFetcher, projectFetcher, studentFetcher);
+    facultyFetcher = mock(FacultyFetcher.class);
+    fetcherModuleController = new FetcherModuleController(disciplineFetcher, projectFetcher, studentFetcher, facultyFetcher);
   }
 
   @Test

--- a/backend/src/test/java/COMP_49X_our_search/backend/fetcher/ProjectFetcherTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/fetcher/ProjectFetcherTest.java
@@ -61,6 +61,7 @@ public class ProjectFetcherTest {
     fall25.setName("Fall 2025");
 
     Faculty faculty = new Faculty();
+    faculty.setId(1);
     faculty.setFirstName("Dr.");
     faculty.setLastName("Faculty");
     faculty.setEmail("faculty@test.com");
@@ -109,6 +110,7 @@ public class ProjectFetcherTest {
 
     // Set up faculty
     Faculty mathFaculty = new Faculty();
+    mathFaculty.setId(1);
     mathFaculty.setFirstName("Dr.");
     mathFaculty.setLastName("Math");
     mathFaculty.setEmail("math@test.com");
@@ -205,6 +207,7 @@ public class ProjectFetcherTest {
 
     // Set up faculty
     Faculty commFaculty = new Faculty();
+    commFaculty.setId(1);
     commFaculty.setFirstName("Dr.");
     commFaculty.setLastName("Comm");
     commFaculty.setEmail("comm@test.com");

--- a/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileRetrieverTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/profile/FacultyProfileRetrieverTest.java
@@ -74,6 +74,7 @@ public class FacultyProfileRetrieverTest {
 
     FacultyProto expectedFacultyProto =
         FacultyProto.newBuilder()
+            .setFacultyId(1)
             .setFirstName("Faculty")
             .setLastName("Member")
             .setEmail("faculty@test.com")

--- a/backend/src/test/java/COMP_49X_our_search/backend/util/ProtoConverterTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/util/ProtoConverterTest.java
@@ -61,6 +61,7 @@ public class ProtoConverterTest {
     researchPeriodEntity.setName("Fall 2025");
 
     Faculty facultyEntity = new Faculty();
+    facultyEntity.setId(1);
     facultyEntity.setFirstName("Dr.");
     facultyEntity.setLastName("Faculty");
     facultyEntity.setEmail("faculty@test.com");
@@ -88,6 +89,7 @@ public class ProtoConverterTest {
             .addResearchPeriods("Fall 2025")
             .setFaculty(
                 FacultyProto.newBuilder()
+                    .setFacultyId(1)
                     .setFirstName("Dr.")
                     .setLastName("Faculty")
                     .setEmail("faculty@test.com"))
@@ -100,12 +102,14 @@ public class ProtoConverterTest {
   @Test
   public void testToFacultyProto_returnsExpectedResult() {
     Faculty facultyEntity = new Faculty();
+    facultyEntity.setId(1);
     facultyEntity.setFirstName("Dr.");
     facultyEntity.setLastName("Faculty");
     facultyEntity.setEmail("faculty@test.com");
 
     FacultyProto expected =
         FacultyProto.newBuilder()
+            .setFacultyId(1)
             .setFirstName("Dr.")
             .setLastName("Faculty")
             .setEmail("faculty@test.com")


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added `GET` `/all-faculty` endpoint to retrieve a list of faculty members grouped by department.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added `FacultyFetcher` in the `Fetcher` module that will be responsible for retrieving all faculty members and grouping them by department.
- Added extra query methods in the hibernate entity services to support the needed operations.
- Made changes to DTOs to support the expected response format.

## End-to-End Testing Instructions

1. Make sure the frontend app, backend app, and the mysql database are running and that there is valid data in the database, specifically valid faculty data, and valid project data.
2. Send `GET` request to endpoint `localhost:8080/all-faculty` and verify that the response is as expected.