### PR TITLE
Implement delete project endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/ProjectRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/ProjectRepository.java
@@ -10,7 +10,6 @@ package COMP_49X_our_search.backend.database.repositories;
 
 import COMP_49X_our_search.backend.database.entities.Project;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/ProjectRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/ProjectRepository.java
@@ -10,6 +10,7 @@ package COMP_49X_our_search.backend.database.repositories;
 
 import COMP_49X_our_search.backend.database.entities.Project;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/ProjectService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/ProjectService.java
@@ -1,10 +1,8 @@
 /**
- * Service class for managing Project entities. This class provides business
- * logic for retrieving project data from the database through the
- * ProjectRepository.
+ * Service class for managing Project entities. This class provides business logic for retrieving
+ * project data from the database through the ProjectRepository.
  *
- * This service is annotated with @Service to indicate that it's managed by
- * Spring.
+ * <p>This service is annotated with @Service to indicate that it's managed by Spring.
  *
  * @author Augusto Escudero
  */
@@ -47,5 +45,13 @@ public class ProjectService {
 
   public Project saveProject(Project project) {
     return projectRepository.save(project);
+  }
+
+  @Transactional
+  public void deleteById(int id) {
+    if (!projectRepository.existsById(id)) {
+      throw new RuntimeException("Project not found with id: " + id);
+    }
+    projectRepository.deleteById(id);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -59,6 +59,8 @@ import proto.profile.ProfileModule.RetrieveProfileRequest;
 import proto.profile.ProfileModule.RetrieveProfileResponse;
 import proto.project.ProjectModule.CreateProjectRequest;
 import proto.project.ProjectModule.CreateProjectResponse;
+import proto.project.ProjectModule.DeleteProjectRequest;
+import proto.project.ProjectModule.DeleteProjectResponse;
 import proto.project.ProjectModule.ProjectRequest;
 
 @RestController
@@ -582,8 +584,7 @@ public class GatewayController {
   }
 
   @DeleteMapping("/student")
-  public ResponseEntity<Void> deleteStudent(
-      @RequestBody DeleteStudentRequestDTO deleteStudentRequestDTO) {
+  public ResponseEntity<Void> deleteStudent(@RequestBody DeleteRequestDTO deleteStudentRequestDTO) {
     String studentEmail = studentService.getStudentById(deleteStudentRequestDTO.getId()).getEmail();
     ModuleConfig moduleConfig =
         ModuleConfig.newBuilder()
@@ -596,6 +597,25 @@ public class GatewayController {
     DeleteProfileResponse deleteProfileResponse =
         response.getProfileResponse().getDeleteProfileResponse();
     if (deleteProfileResponse.getSuccess()) {
+      return ResponseEntity.ok().build();
+    }
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+  }
+
+  @DeleteMapping("/project")
+  public ResponseEntity<Void> deleteProject(@RequestBody DeleteRequestDTO deleteProjectRequestDTO) {
+    ModuleConfig moduleConfig =
+        ModuleConfig.newBuilder()
+            .setProjectRequest(
+                ProjectRequest.newBuilder()
+                    .setDeleteProjectRequest(
+                        DeleteProjectRequest.newBuilder()
+                            .setProjectId(deleteProjectRequestDTO.getId())))
+            .build();
+    ModuleResponse response = moduleInvoker.processConfig(moduleConfig);
+    DeleteProjectResponse deleteProjectResponse =
+        response.getProjectResponse().getDeleteProjectResponse();
+    if (deleteProjectResponse.getSuccess()) {
       return ResponseEntity.ok().build();
     }
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/DeleteRequestDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/DeleteRequestDTO.java
@@ -1,9 +1,9 @@
 package COMP_49X_our_search.backend.gateway.dto;
 
-public class DeleteStudentRequestDTO {
+public class DeleteRequestDTO {
   private int id;
 
-  public DeleteStudentRequestDTO() {}
+  public DeleteRequestDTO() {}
 
   public int getId() {
     return id;

--- a/backend/src/main/java/COMP_49X_our_search/backend/project/ProjectDeleter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/project/ProjectDeleter.java
@@ -1,0 +1,35 @@
+package COMP_49X_our_search.backend.project;
+
+import COMP_49X_our_search.backend.database.entities.Project;
+import COMP_49X_our_search.backend.database.services.ProjectService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import proto.project.ProjectModule.DeleteProjectRequest;
+import proto.project.ProjectModule.DeleteProjectResponse;
+
+@Service
+public class ProjectDeleter {
+
+  private final ProjectService projectService;
+
+  @Autowired
+  public ProjectDeleter(ProjectService projectService) {
+    this.projectService = projectService;
+  }
+
+  public DeleteProjectResponse deleteProject(DeleteProjectRequest request) {
+    // No need to validate the request itself for now since it only asks for the
+    // project id, which defaults to 0 if not set, so we can just call the
+    // project service which throws an exception if the project is not found.
+    try {
+      projectService.deleteById(request.getProjectId());
+
+      return DeleteProjectResponse.newBuilder().setSuccess(true).build();
+    } catch (Exception e) {
+      return DeleteProjectResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMessage("Error deleting project: " + e.getMessage())
+          .build();
+    }
+    }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/project/ProjectModuleController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/project/ProjectModuleController.java
@@ -1,12 +1,10 @@
 /**
- * Controller class for managing project-related operations. This class maps
- * project operation types to their corresponding project creation, editing, or
- * deletion implementations and processes requests accordingly.
+ * Controller class for managing project-related operations. This class maps project operation types
+ * to their corresponding project creation, editing, or deletion implementations and processes
+ * requests accordingly.
  *
- * <p>Supported operations:
- * - **Project Creation** (currently supported)
- * - **Project Editing** (planned)
- * - **Project Deletion** (planed)
+ * <p>Supported operations: - **Project Creation** (currently supported) - **Project Editing**
+ * (planned) - **Project Deletion** (planed)
  *
  * <p>Implements the ModuleController interface.
  *
@@ -26,10 +24,12 @@ import proto.project.ProjectModule.ProjectResponse;
 public class ProjectModuleController implements ModuleController {
 
   private final ProjectCreator projectCreator;
+  private final ProjectDeleter projectDeleter;
 
   @Autowired
-  public ProjectModuleController(ProjectCreator projectCreator) {
+  public ProjectModuleController(ProjectCreator projectCreator, ProjectDeleter projectDeleter) {
     this.projectCreator = projectCreator;
+    this.projectDeleter = projectDeleter;
   }
 
   @Override
@@ -47,6 +47,14 @@ public class ProjectModuleController implements ModuleController {
                     // to the Profile module if we decide to have multiple
                     // different implementations of Project creation.
                     projectCreator.createProject(request.getCreateProjectRequest()))
+                .build();
+        break;
+      case DELETE_PROJECT_REQUEST:
+        response =
+            ProjectResponse.newBuilder()
+                .setDeleteProjectResponse(
+                    // See above comment
+                    projectDeleter.deleteProject(request.getDeleteProjectRequest()))
                 .build();
         break;
       // Add more cases as we add more operation types, e.g., edit, delete

--- a/backend/src/main/proto/project/project_module.proto
+++ b/backend/src/main/proto/project/project_module.proto
@@ -11,6 +11,7 @@ import "data/entities.proto";
 message ProjectRequest {
   oneof operation_request {
     CreateProjectRequest create_project_request = 1;
+    DeleteProjectRequest delete_project_request = 2;
     // Add more as we add more operation types, e.g. editing, deleting.
   }
 }
@@ -18,6 +19,7 @@ message ProjectRequest {
 message ProjectResponse {
   oneof operation_response {
     CreateProjectResponse create_project_response = 1;
+    DeleteProjectResponse delete_project_response = 2;
     // Add more as we add more operation types, e.g. editing, deleting.
   }
 }
@@ -32,4 +34,13 @@ message CreateProjectResponse {
   int32 project_id = 2;
   string error_message = 3;
   data.ProjectProto created_project = 4;
+}
+
+message DeleteProjectRequest {
+  int32 project_id = 1;
+}
+
+message DeleteProjectResponse {
+  bool success = 1;
+  string error_message = 2;
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/ProjectServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/ProjectServiceTest.java
@@ -1,8 +1,10 @@
 package COMP_49X_our_search.backend.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -116,5 +118,32 @@ public class ProjectServiceTest {
     assertEquals(sampleProject.getName(), savedProject.getName());
     assertEquals(sampleProject.getDescription(), savedProject.getDescription());
     assertEquals(sampleProject.getFaculty().getEmail(), savedProject.getFaculty().getEmail());
+  }
+
+  @Test
+  void testDeleteById_existingProject_deletesSuccessfully() {
+    int projectId = 1;
+
+    when(projectRepository.existsById(projectId)).thenReturn(true);
+
+    projectService.deleteById(projectId);
+
+    verify(projectRepository, times(1)).deleteById(projectId);
+  }
+
+  @Test
+  void testDeleteById_nonExistingProject_throwsException() {
+    int nonExistingId = 999;
+
+    when(projectRepository.existsById(nonExistingId)).thenReturn(false);
+
+    RuntimeException exception = assertThrows(
+        RuntimeException.class,
+        () -> projectService.deleteById(nonExistingId)
+    );
+
+    assertEquals("Project not found with id: " + nonExistingId, exception.getMessage());
+
+    verify(projectRepository, never()).deleteById(nonExistingId);
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -14,7 +14,7 @@ import COMP_49X_our_search.backend.database.services.*;
 import COMP_49X_our_search.backend.gateway.dto.CreateFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.CreateProjectRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.CreateStudentRequestDTO;
-import COMP_49X_our_search.backend.gateway.dto.DeleteStudentRequestDTO;
+import COMP_49X_our_search.backend.gateway.dto.DeleteRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.DisciplineDTO;
 import COMP_49X_our_search.backend.gateway.dto.EditFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.EditStudentRequestDTO;
@@ -64,6 +64,8 @@ import proto.profile.ProfileModule.FacultyProfile;
 import proto.profile.ProfileModule.ProfileResponse;
 import proto.profile.ProfileModule.RetrieveProfileResponse;
 import proto.project.ProjectModule.CreateProjectResponse;
+import proto.project.ProjectModule.DeleteProjectResponse;
+import proto.project.ProjectModule.ProjectResponse;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -759,7 +761,7 @@ public class GatewayControllerTest {
     student.setId(studentId);
     student.setEmail("student@test.com");
 
-    DeleteStudentRequestDTO deleteStudentRequestDTO = new DeleteStudentRequestDTO();
+    DeleteRequestDTO deleteStudentRequestDTO = new DeleteRequestDTO();
     deleteStudentRequestDTO.setId(studentId);
 
     // Mock studentService response
@@ -787,6 +789,33 @@ public class GatewayControllerTest {
 
     // Verify interactions
     verify(studentService, times(1)).getStudentById(studentId);
+    verify(moduleInvoker, times(1)).processConfig(any(ModuleConfig.class));
+  }
+
+  @Test
+  @WithMockUser
+  void deleteProject_success_returnsOk() throws Exception {
+    DeleteRequestDTO deleteProjectRequestDTO = new DeleteRequestDTO();
+    deleteProjectRequestDTO.setId(1);
+
+    DeleteProjectResponse deleteProjectResponse =
+        DeleteProjectResponse.newBuilder().setSuccess(true).build();
+
+    ModuleResponse moduleResponse =
+        ModuleResponse.newBuilder()
+            .setProjectResponse(
+                ProjectResponse.newBuilder()
+                    .setDeleteProjectResponse(deleteProjectResponse))
+            .build();
+
+    when(moduleInvoker.processConfig(any(ModuleConfig.class))).thenReturn(moduleResponse);
+
+    mockMvc
+        .perform(delete("/project")
+            .contentType("application/json")
+            .content(objectMapper.writeValueAsString(deleteProjectRequestDTO)))
+        .andExpect(status().isOk());
+
     verify(moduleInvoker, times(1)).processConfig(any(ModuleConfig.class));
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/project/ProjectCreatorTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/project/ProjectCreatorTest.java
@@ -1,0 +1,101 @@
+package COMP_49X_our_search.backend.project;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import COMP_49X_our_search.backend.database.services.FacultyService;
+import COMP_49X_our_search.backend.database.services.MajorService;
+import COMP_49X_our_search.backend.database.services.ProjectService;
+import COMP_49X_our_search.backend.database.services.ResearchPeriodService;
+import COMP_49X_our_search.backend.database.services.UmbrellaTopicService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import proto.data.Entities.FacultyProto;
+import proto.data.Entities.ProjectProto;
+import proto.project.ProjectModule.CreateProjectRequest;
+
+public class ProjectCreatorTest {
+
+  private ProjectService projectService;
+  private FacultyService facultyService;
+  private MajorService majorService;
+  private UmbrellaTopicService umbrellaTopicService;
+  private ResearchPeriodService researchPeriodService;
+  private ProjectCreator projectCreator;
+
+  @BeforeEach
+  void setUp() {
+    projectService = mock(ProjectService.class);
+    facultyService = mock(FacultyService.class);
+    majorService = mock(MajorService.class);
+    umbrellaTopicService = mock(UmbrellaTopicService.class);
+    researchPeriodService = mock(ResearchPeriodService.class);
+    projectCreator =
+        new ProjectCreator(
+            projectService,
+            facultyService,
+            majorService,
+            umbrellaTopicService,
+            researchPeriodService);
+  }
+
+  @Test
+  public void testCreateProject_validProjectData_returnsExpectedResult() {
+    // TODO(acescudero): Implement
+  }
+
+  @Test
+  public void testCreateProject_invalidProjectData_throwsException() {
+    ProjectProto invalidProject =
+        ProjectProto.newBuilder().setProjectName("").setDescription("Test").build();
+
+    CreateProjectRequest request =
+        CreateProjectRequest.newBuilder().setProject(invalidProject).build();
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> projectCreator.createProject(request));
+
+    assertTrue(
+        exception
+            .getMessage()
+            .contains(
+                "ProjectProto must have valid following fields: "
+                    + "project_name, description, desired_qualifications, majors, "
+                    + "umbrella_topics, research_periods"));
+  }
+
+  @Test
+  public void testCreateProject_validProjectData_invalidFacultyData_throwsException() {
+    FacultyProto invalidFaculty = FacultyProto.getDefaultInstance();
+    ProjectProto validProjectWithInvalidFaculty =
+        ProjectProto.newBuilder()
+            .setProjectName("Name")
+            .setDescription("Description")
+            .setDesiredQualifications("Qualifications")
+            .addMajors("Major")
+            .addUmbrellaTopics("Topic")
+            .addResearchPeriods("Period")
+            .setFaculty(invalidFaculty)
+            .build();
+
+    CreateProjectRequest request =
+        CreateProjectRequest.newBuilder().setProject(validProjectWithInvalidFaculty).build();
+
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> projectCreator.createProject(request));
+
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("ProjectProto must have 'FacultyProto' with 'email' field set"));
+  }
+
+  @Test
+  public void testCreateProject_invalidRequest_throwsException() {
+    CreateProjectRequest request = CreateProjectRequest.getDefaultInstance();
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> projectCreator.createProject(request));
+
+    assertTrue(exception.getMessage().contains("CreateProjectRequest must contain 'project'"));
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/project/ProjectDeleterTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/project/ProjectDeleterTest.java
@@ -1,0 +1,62 @@
+package COMP_49X_our_search.backend.project;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import COMP_49X_our_search.backend.database.services.ProjectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import proto.project.ProjectModule.DeleteProjectRequest;
+import proto.project.ProjectModule.DeleteProjectResponse;
+
+public class ProjectDeleterTest {
+
+  private ProjectService projectService;
+  private ProjectDeleter projectDeleter;
+
+  @BeforeEach
+  void setUp() {
+    projectService = mock(ProjectService.class);
+    projectDeleter = new ProjectDeleter(projectService);
+  }
+
+  @Test
+  public void testDeleteProject_deletionSuccessful_returnsExpectedResponse() {
+    int projectId = 42;
+    DeleteProjectRequest request = DeleteProjectRequest.newBuilder()
+        .setProjectId(projectId)
+        .build();
+
+    doNothing().when(projectService).deleteById(projectId);
+
+    DeleteProjectResponse response = projectDeleter.deleteProject(request);
+
+    assertTrue(response.getSuccess());
+    assertEquals("", response.getErrorMessage());
+    verify(projectService, times(1)).deleteById(projectId);
+  }
+
+  @Test
+  public void testDeleteProject_projectNotFound_returnsErrorResponse() {
+    int nonExistentProjectId = 999;
+    DeleteProjectRequest request = DeleteProjectRequest.newBuilder()
+        .setProjectId(nonExistentProjectId)
+        .build();
+
+    String errorMessage = "Project not found with id: " + nonExistentProjectId;
+    doThrow(new RuntimeException(errorMessage))
+        .when(projectService).deleteById(nonExistentProjectId);
+
+    DeleteProjectResponse response = projectDeleter.deleteProject(request);
+
+    assertFalse(response.getSuccess());
+    assertEquals("Error deleting project: " + errorMessage, response.getErrorMessage());
+    verify(projectService, times(1)).deleteById(nonExistentProjectId);
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/project/ProjectModuleControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/project/ProjectModuleControllerTest.java
@@ -20,11 +20,13 @@ public class ProjectModuleControllerTest {
 
   private ProjectModuleController projectModuleController;
   private ProjectCreator projectCreator;
+  private ProjectDeleter projectDeleter;
 
   @BeforeEach
   void setUp() {
     projectCreator = mock(ProjectCreator.class);
-    projectModuleController = new ProjectModuleController(projectCreator);
+    projectDeleter = mock(ProjectDeleter.class);
+    projectModuleController = new ProjectModuleController(projectCreator, projectDeleter);
   }
 
   @Test


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added `DELETE` mapping at `/project` endpoint to delete a specific project by its id.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added `ProjectDeleter` class in `Project` module that will be responsible for deleting a specific project by its id.
- Added extra query methods in the jpa entity services to support the needed operations.
- Renamed `DeleteStudentRequestDTO` to `DeleteRequestDTO`. All delete requests for admin users will have the same format, i.e. they will contain the `id` field, so having a single `DeleteRequestDTO` allows us to re-use code.

## End-to-End Testing Instructions

1. Make sure the frontend app, backend app, and the mysql database are running and that there is valid project data in the database.
2. Send `DELETE` request to endpoint `localhost:8080/project` including the `id` in the request body and verify that the response is as expected, and that the project was successfully deleted from the database.