### PR TITLE
Fixed bug rendering number of posts available

### DIFF
--- a/frontend/src/components/MainAccordion.js
+++ b/frontend/src/components/MainAccordion.js
@@ -29,11 +29,12 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
       )
     }
 
+    // numPosts definition: only want to show number of ACTIVE postings to students & faculty; admin can see all
     return discipline.majors.map((major) => (
       <MajorAccordion
         key={major.id}
         major={major}
-        numPosts={major.posts.length}
+        numPosts={(isStudent || isFaculty) ? major.posts.filter((post) => post.isActive).length : major.posts.length}
         setSelectedPost={setSelectedPost}
         isStudent={isStudent}
         isFaculty={isFaculty}


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** 
The frontend had a bug where if on student or faculty view it would show "1 opportunity" even though there were none to display. This is because the code did not filter out length of inactive postings when determining the number of posts. 

## End-to-End Testing Instructions
1. make sure database has projects and students in it
2. login as student or faculty
3. see accordion dropdowns with numbers of posts rendered correctly

Alternatively,
1. login as admin
2. see all active and inactive postings with correct number displayed