### PR TITLE
Implemented edit specific major endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/DisciplineRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/DisciplineRepository.java
@@ -9,8 +9,10 @@
 package COMP_49X_our_search.backend.database.repositories;
 
 import COMP_49X_our_search.backend.database.entities.Discipline;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DisciplineRepository
     extends JpaRepository<Discipline, Integer> {
+  Optional<Discipline> findByName(String name);
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
@@ -30,4 +30,10 @@ public class DisciplineService {
   public List<Discipline> getAllDisciplines() {
     return disciplineRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
   }
+
+  public Discipline getDisciplineByName(String name) {
+    return disciplineRepository
+        .findByName(name)
+        .orElseThrow(() -> new RuntimeException("Major not found with name: " + name));
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/MajorService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/MajorService.java
@@ -1,10 +1,8 @@
 /**
- * Service class for managing Major entities. This class provides business
- * logic for retrieving major data from the database through the
- * MajorRepository.
+ * Service class for managing Major entities. This class provides business logic for retrieving
+ * major data from the database through the MajorRepository.
  *
- * This service is annotated with @Service to indicate that it's managed by
- * Spring.
+ * <p>This service is annotated with @Service to indicate that it's managed by Spring.
  *
  * @author Augusto Escudero
  */
@@ -38,5 +36,15 @@ public class MajorService {
 
   public Optional<Major> getMajorByName(String name) {
     return majorRepository.findMajorByName(name);
+  }
+
+  public Major getMajorById(int id) {
+    return majorRepository
+        .findById(id)
+        .orElseThrow(() -> new RuntimeException("Major not found with id: " + id));
+  }
+
+  public Major saveMajor(Major major) {
+    return majorRepository.save(major);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/EditMajorRequestDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/EditMajorRequestDTO.java
@@ -1,0 +1,42 @@
+package COMP_49X_our_search.backend.gateway.dto;
+
+import java.util.List;
+
+public class EditMajorRequestDTO {
+
+  private int id;
+  private String name;
+  private List<String> disciplines;
+
+  public EditMajorRequestDTO() {}
+
+  public EditMajorRequestDTO(int id, String name, List<String> disciplines) {
+    this.id = id;
+    this.name = name;
+    this.disciplines = disciplines;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getDisciplines() {
+    return disciplines;
+  }
+
+  public void setDisciplines(List<String> disciplines) {
+    this.disciplines = disciplines;
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
@@ -2,11 +2,13 @@ package COMP_49X_our_search.backend.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.repositories.DisciplineRepository;
 import COMP_49X_our_search.backend.database.services.DisciplineService;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +32,7 @@ public class DisciplineServiceTest {
     Discipline engineeringDiscipline = new Discipline("Engineering");
     Discipline lifeSciencesDiscipline = new Discipline("Life Sciences");
 
-    Mockito.when(disciplineRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
+    when(disciplineRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
         .thenReturn(List.of(engineeringDiscipline, lifeSciencesDiscipline));
 
     List<Discipline> disciplines = disciplineService.getAllDisciplines();
@@ -38,5 +40,19 @@ public class DisciplineServiceTest {
     assertEquals(2, disciplines.size());
     assertTrue(disciplines
         .containsAll(List.of(engineeringDiscipline, lifeSciencesDiscipline)));
+  }
+
+  @Test
+  void testGetDisciplineByName() {
+    Discipline engineeringDiscipline = new Discipline();
+    engineeringDiscipline.setId(1);
+    engineeringDiscipline.setName("Engineering");
+
+    when(disciplineRepository.findByName("Engineering")).thenReturn(Optional.of(engineeringDiscipline));
+
+    Discipline dbDiscipline = disciplineService.getDisciplineByName("Engineering");
+
+    assertEquals(engineeringDiscipline.getName(), dbDiscipline.getName());
+    assertEquals(engineeringDiscipline.getId(), dbDiscipline.getId());
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/MajorServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/MajorServiceTest.java
@@ -2,6 +2,10 @@ package COMP_49X_our_search.backend.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Major;
@@ -24,11 +28,9 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 public class MajorServiceTest {
 
-  @Autowired
-  private MajorService majorService;
+  @Autowired private MajorService majorService;
 
-  @MockBean
-  private MajorRepository majorRepository;
+  @MockBean private MajorRepository majorRepository;
 
   private Discipline engineeringDiscipline;
 
@@ -39,12 +41,10 @@ public class MajorServiceTest {
 
   @Test
   void testGetAllMajors() {
-    Major csMajor = new Major("Computer Science", Set.of(engineeringDiscipline),
-        null, null);
-    Major mathMajor =
-        new Major("Mathematics", Set.of(engineeringDiscipline), null, null);
+    Major csMajor = new Major("Computer Science", Set.of(engineeringDiscipline), null, null);
+    Major mathMajor = new Major("Mathematics", Set.of(engineeringDiscipline), null, null);
 
-    Mockito.when(majorRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
+    when(majorRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
         .thenReturn((List.of(csMajor, mathMajor)));
 
     List<Major> majors = majorService.getAllMajors();
@@ -57,9 +57,10 @@ public class MajorServiceTest {
   void testGetMajorsByDisciplineId() {
     int disciplineId = 1;
     Major csMajor = new Major("Computer Science", Set.of(engineeringDiscipline), null, null);
-    Major mechanicalMajor = new Major("Mechanical Engineering", Set.of(engineeringDiscipline), null, null);
+    Major mechanicalMajor =
+        new Major("Mechanical Engineering", Set.of(engineeringDiscipline), null, null);
 
-    Mockito.when(majorRepository.findAllByDisciplines_Id(disciplineId))
+    when(majorRepository.findAllByDisciplines_Id(disciplineId))
         .thenReturn(List.of(csMajor, mechanicalMajor));
 
     List<Major> majors = majorService.getMajorsByDisciplineId(disciplineId);
@@ -73,8 +74,7 @@ public class MajorServiceTest {
     String majorName = "Computer Science";
     Major csMajor = new Major(majorName, Set.of(engineeringDiscipline), null, null);
 
-    Mockito.when(majorRepository.findMajorByName(majorName))
-        .thenReturn(Optional.of(csMajor));
+    when(majorRepository.findMajorByName(majorName)).thenReturn(Optional.of(csMajor));
 
     Optional<Major> major = majorService.getMajorByName(majorName);
 
@@ -86,11 +86,43 @@ public class MajorServiceTest {
   void testGetMajorByName_NotFound() {
     String majorName = "Astronomy";
 
-    Mockito.when(majorRepository.findMajorByName(majorName))
-        .thenReturn(Optional.empty());
+    when(majorRepository.findMajorByName(majorName)).thenReturn(Optional.empty());
 
     Optional<Major> major = majorService.getMajorByName(majorName);
 
     assertTrue(major.isEmpty());
+  }
+
+  @Test
+  void testGetMajorById() {
+    Major computerScience = new Major();
+    computerScience.setId(1);
+    computerScience.setName("Computer Science");
+
+    when(majorRepository.findById(1))
+        .thenReturn(Optional.of(computerScience));
+
+    Major dbMajor = majorService.getMajorById(1);
+
+    assertEquals(computerScience.getName(), dbMajor.getName());
+    assertEquals(computerScience.getId(), dbMajor.getId());
+  }
+
+  @Test
+  void testSaveMajor() {
+    Major computerScience = new Major();
+    computerScience.setId(1);
+    computerScience.setName("Computer Science");
+    computerScience.setDisciplines(Set.of(new Discipline("Engineering")));
+
+    when(majorRepository.save(any(Major.class))).thenReturn(computerScience);
+
+    Major savedMajor = majorService.saveMajor(computerScience);
+
+    assertEquals(computerScience.getId(), savedMajor.getId());
+    assertEquals(computerScience.getName(), savedMajor.getName());
+    assertEquals(computerScience.getDisciplines(), savedMajor.getDisciplines());
+
+    verify(majorRepository, times(1)).save(computerScience);
   }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added `PUT` mapping at `/major` endpoint to edit a specific major by its id.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added extra query methods in the jpa services to support the needed operations.

## End-to-End Testing Instructions

1. Make sure the frontend app, backend app, and the mysql database are running and that there is valid major and discipline data in the database.
2. Send `PUT` request to endpoint `localhost:8080/major` icluding the appropriate data in the request body and verify that the response is as expected, and that the major was successfully edited.