### PR TITLE
Implemented delete specific discipline endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Discipline.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Discipline.java
@@ -34,6 +34,9 @@ public class Discipline {
   @ManyToMany(mappedBy = "disciplines")
   private Set<Major> majors = new HashSet<>();
 
+  @ManyToMany(mappedBy = "disciplines")
+  private Set<Student> students = new HashSet<>();
+
   public Discipline() {}
 
   public Discipline(String name) {
@@ -75,5 +78,13 @@ public class Discipline {
 
   public void setMajors(Set<Major> majors) {
     this.majors = majors;
+  }
+
+  public Set<Student> getStudents() {
+    return students;
+  }
+
+  public void setStudents(Set<Student> students) {
+    this.students = students;
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Student.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Student.java
@@ -9,6 +9,7 @@
  */
 package COMP_49X_our_search.backend.database.entities;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -52,7 +53,7 @@ public class Student {
   @Column(nullable = false)
   private Boolean isActive;
 
-  @ManyToMany
+  @ManyToMany(cascade = {CascadeType.MERGE})
   @JoinTable(name = "students_disciplines",
       joinColumns = @JoinColumn(name = "student_id"),
       inverseJoinColumns = @JoinColumn(name = "discipline_id"))

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
@@ -11,20 +11,27 @@
 package COMP_49X_our_search.backend.database.services;
 
 import COMP_49X_our_search.backend.database.entities.Discipline;
+import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.repositories.DisciplineRepository;
+import COMP_49X_our_search.backend.database.repositories.MajorRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class DisciplineService {
 
   private final DisciplineRepository disciplineRepository;
+  private final MajorRepository majorRepository;
 
   @Autowired
-  public DisciplineService(DisciplineRepository disciplineRepository) {
+  public DisciplineService(DisciplineRepository disciplineRepository, MajorRepository majorRepository) {
     this.disciplineRepository = disciplineRepository;
+    this.majorRepository = majorRepository;
   }
 
   public List<Discipline> getAllDisciplines() {
@@ -35,5 +42,31 @@ public class DisciplineService {
     return disciplineRepository
         .findByName(name)
         .orElseThrow(() -> new RuntimeException("Major not found with name: " + name));
+  }
+
+  @Transactional
+  public void deleteDisciplineById(int id) {
+    Discipline discipline = disciplineRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException(
+            String.format("Cannot delete discipline with id '%s'. Discipline not found.", id)
+        ));
+
+    Set<Major> associatedMajors = new HashSet<>(discipline.getMajors());
+
+    // Since we have a majors_disciplines table, when we delete a discipline we
+    // have to remove the relationship from each major, e.g. if Computer Science
+    // belongs to the Engineering and Mathematics disciplines, and we remove
+    // Mathematics, we should first remove the Computer Science <-> Mathematics
+    // relationship.
+    associatedMajors
+        .forEach(major -> {
+          major.getDisciplines().remove(discipline);
+          majorRepository.save(major);
+        });
+
+    discipline.getMajors().clear();
+    disciplineRepository.save(discipline);
+
+    disciplineRepository.deleteById(id);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
@@ -24,7 +24,7 @@ public class DisciplineService {
 
   private final DisciplineRepository disciplineRepository;
   @Autowired
-  public DisciplineService(DisciplineRepository disciplineRepository, MajorRepository majorRepository) {
+  public DisciplineService(DisciplineRepository disciplineRepository) {
     this.disciplineRepository = disciplineRepository;
   }
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -833,4 +833,14 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
+
+  @DeleteMapping("/discipline")
+  public ResponseEntity<Void> deleteDiscipline(@RequestBody DeleteRequestDTO requestBody) {
+    try {
+      disciplineService.deleteDisciplineById(requestBody.getId());
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
@@ -1,14 +1,25 @@
 package COMP_49X_our_search.backend.database;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import COMP_49X_our_search.backend.database.entities.Discipline;
+import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.repositories.DisciplineRepository;
+import COMP_49X_our_search.backend.database.repositories.MajorRepository;
 import COMP_49X_our_search.backend.database.services.DisciplineService;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +37,8 @@ public class DisciplineServiceTest {
 
   @MockBean
   private DisciplineRepository disciplineRepository;
+  @MockBean
+  private MajorRepository majorRepository;
 
   @Test
   void testGetAllDisciplines() {
@@ -54,5 +67,68 @@ public class DisciplineServiceTest {
 
     assertEquals(engineeringDiscipline.getName(), dbDiscipline.getName());
     assertEquals(engineeringDiscipline.getId(), dbDiscipline.getId());
+  }
+
+  @Test
+  void deleteDisciplineById_whenDisciplineExists_deleteSuccessfully() {
+    int disciplineId = 1;
+    Discipline discipline = new Discipline(disciplineId, "Engineering");
+    Major major1 = new Major(1, "Computer Science");
+    Major major2 = new Major(2, "Electrical Engineering");
+
+    Set<Major> majors = new HashSet<>();
+    majors.add(major1);
+    majors.add(major2);
+    discipline.setMajors(majors);
+
+    when(disciplineRepository.findById(disciplineId)).thenReturn(Optional.of(discipline));
+    doNothing().when(disciplineRepository).deleteById(disciplineId);
+
+    disciplineService.deleteDisciplineById(disciplineId);
+
+    verify(disciplineRepository, times(1)).findById(disciplineId);
+    verify(majorRepository, times(1)).save(major1);
+    verify(majorRepository, times(1)).save(major2);
+    verify(disciplineRepository, times(1)).save(discipline);
+    verify(disciplineRepository, times(1)).deleteById(disciplineId);
+  }
+
+  @Test
+  void deleteDisciplineById_disciplineDoesNotExist_throwsException() {
+    int disciplineId = 999;
+    when(disciplineRepository.findById(disciplineId)).thenReturn(Optional.empty());
+
+    RuntimeException exception = assertThrows(
+        RuntimeException.class,
+        () -> disciplineService.deleteDisciplineById(disciplineId)
+    );
+
+    String expectedMessage = String.format(
+        "Cannot delete discipline with id '%s'. Discipline not found.", disciplineId
+    );
+    String actualMessage = exception.getMessage();
+    assertTrue(actualMessage.contains(expectedMessage));
+
+    verify(disciplineRepository, times(1)).findById(disciplineId);
+    verify(disciplineRepository, never()).save(any(Discipline.class));
+    verify(disciplineRepository, never()).deleteById(anyInt());
+    verify(majorRepository, never()).save(any(Major.class));
+  }
+
+  @Test
+  void deleteDisciplineById_disciplineHasNoMajors_deleteSuccessfully() {
+    int disciplineId = 1;
+    Discipline discipline = new Discipline(disciplineId, "Engineering");
+    discipline.setMajors(new HashSet<>());
+
+    when(disciplineRepository.findById(disciplineId)).thenReturn(Optional.of(discipline));
+    doNothing().when(disciplineRepository).deleteById(disciplineId);
+
+    disciplineService.deleteDisciplineById(disciplineId);
+
+    verify(disciplineRepository, times(1)).findById(disciplineId);
+    verify(disciplineRepository, times(1)).save(discipline);
+    verify(disciplineRepository, times(1)).deleteById(disciplineId);
+    verify(majorRepository, never()).save(any(Major.class)); // No majors should be saved
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1152,4 +1152,21 @@ public class GatewayControllerTest {
     verify(disciplineService, times(1)).getDisciplineByName("Life and Physical Sciences");
     verify(majorService, times(1)).saveMajor(any(Major.class));
   }
+
+  @Test
+  @WithMockUser
+  void deleteDiscipline_returnsExpectedResult() throws Exception {
+    DeleteRequestDTO deleteRequestDTO = new DeleteRequestDTO();
+    deleteRequestDTO.setId(1);
+
+    doNothing().when(disciplineService).deleteDisciplineById(1);
+
+    mockMvc
+        .perform(delete("/discipline")
+            .contentType("application/json")
+            .content(objectMapper.writeValueAsString(deleteRequestDTO)))
+        .andExpect(status().isOk());
+
+    verify(disciplineService, times(1)).deleteDisciplineById(1);
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added `DELETE` mapping at `/discipline` endpoint to delete a specific discipline by its id.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added extra query methods in the jpa services to support the needed operations.

## End-to-End Testing Instructions

1. Make sure the frontend app, the backend app, and the mysql database are running and that there is valid discipline and, though not required, major data in the database.
2. Send `DELETE` request to endpoint `https://localhost:8080/discipline` including the appropriate data in the request body and verify that the response is as expected, and that the discipline was successfully deleted.
