### PR TITLE
Adjust security settings to check for if user is admin

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/authentication/AuthController.java
@@ -45,10 +45,10 @@ public class AuthController {
                     response.put("isStudent", "true");
                 } else if (role == UserRole.FACULTY) {
                     response.put("isFaculty", "true");
+                } else if (role == UserRole.ADMIN) {
+                    response.put("isAdmin", "true");
                 }
             }
-
-            // TODO in later sprint: response.put("isAdmin", "true");
         }
 
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/enums/UserRole.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/enums/UserRole.java
@@ -1,6 +1,6 @@
 /**
  * Defines the user roles in the system, used to specify the role of a student
- * in the app (STUDENT, FACULTY, ADMIN [to be implemented]).
+ * in the app (STUDENT, FACULTY, ADMIN).
  *
  * The UserRole is stored in the "users" table as an enum.
  *
@@ -10,5 +10,6 @@ package COMP_49X_our_search.backend.database.enums;
 
 public enum UserRole {
   STUDENT,
-  FACULTY
+  FACULTY,
+  ADMIN
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/authentication/AuthControllerTest.java
@@ -1,10 +1,9 @@
 /**
- * Tests that the controller for our endpoint to respond with current authentication status returns 
+ * Tests that the controller for our endpoint to respond with current authentication status returns
  * expected responses to the frontend.
- * 
+ *
  * @author Natalie Jungquist
  */
-
 package COMP_49X_our_search.backend.authentication;
 
 import COMP_49X_our_search.backend.database.enums.UserRole;
@@ -25,133 +24,143 @@ import static org.mockito.Mockito.*;
 
 class AuthControllerTest {
 
-    private AuthController authController;
+  private AuthController authController;
 
-    @Mock
-    private OAuthChecker mockOAuthChecker;
+  @Mock private OAuthChecker mockOAuthChecker;
 
-    @Mock
-    private UserService mockUserService;
+  @Mock private UserService mockUserService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        authController = new AuthController(mockOAuthChecker, mockUserService);
-    }
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    authController = new AuthController(mockOAuthChecker, mockUserService);
+  }
 
-    @Test
-    void testCheckAuthStatus_Unauthenticated() {
-        Map<String, String> defaultResponse = Map.of(
-                "isAuthenticated", "false",
-                "isStudent", "false",
-                "isFaculty", "false",
-                "isAdmin", "false"
-        );
+  @Test
+  void testCheckAuthStatus_Unauthenticated() {
+    Map<String, String> defaultResponse =
+        Map.of(
+            "isAuthenticated", "false",
+            "isStudent", "false",
+            "isFaculty", "false",
+            "isAdmin", "false");
 
-        when(mockOAuthChecker.getDefaultResponse()).thenReturn(defaultResponse);
-        when(mockOAuthChecker.isAuthenticated(any())).thenReturn(false);
+    when(mockOAuthChecker.getDefaultResponse()).thenReturn(defaultResponse);
+    when(mockOAuthChecker.isAuthenticated(any())).thenReturn(false);
 
-        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+    ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
-        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-        assertEquals(defaultResponse, response.getBody());
-    }
+    assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    assertEquals(defaultResponse, response.getBody());
+  }
 
-    @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
-    @Test
-    void testCheckAuthStatus_AuthenticatedStudent() {
-        Map<String, String> expectedResponse = Map.of(
-                "isAuthenticated", "true",
-                "isStudent", "true",
-                "isFaculty", "false",
-                "isAdmin", "false"
-        );
+  @SuppressWarnings(
+      "null") // added because if response.getBody().get(...) returns null, the test should fail
+  @Test
+  void testCheckAuthStatus_AuthenticatedStudent() {
+    Map<String, String> expectedResponse =
+        Map.of(
+            "isAuthenticated", "true",
+            "isStudent", "true",
+            "isFaculty", "false",
+            "isAdmin", "false");
 
-        String email = "test@sandiego.edu";
-        Authentication mockAuth = mock(Authentication.class);
-        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
-        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
-        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
-        when(mockUserService.userExists(email)).thenReturn(true);
-        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.STUDENT);
+    String email = "test@sandiego.edu";
+    Authentication mockAuth = mock(Authentication.class);
+    when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+    when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+    when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+    when(mockUserService.userExists(email)).thenReturn(true);
+    when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.STUDENT);
 
-        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+    ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
-        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-        assertEquals(expectedResponse, response.getBody());
-    }
+    assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    assertEquals(
+        expectedResponse.get("isAuthenticated"),
+        Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+    assertEquals(expectedResponse, response.getBody());
+  }
 
-    @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
-    @Test
-    void testCheckAuthStatus_AuthenticatedFaculty() {
-        Map<String, String> expectedResponse = Map.of(
-                "isAuthenticated", "true",
-                "isStudent", "false",
-                "isFaculty", "true",
-                "isAdmin", "false"
-        );
+  @SuppressWarnings(
+      "null") // added because if response.getBody().get(...) returns null, the test should fail
+  @Test
+  void testCheckAuthStatus_AuthenticatedFaculty() {
+    Map<String, String> expectedResponse =
+        Map.of(
+            "isAuthenticated", "true",
+            "isStudent", "false",
+            "isFaculty", "true",
+            "isAdmin", "false");
 
-        String email = "professor@sandiego.edu";
-        Authentication mockAuth = mock(Authentication.class);
-        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
-        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
-        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
-        when(mockUserService.userExists(email)).thenReturn(true);
-        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.FACULTY);
+    String email = "professor@sandiego.edu";
+    Authentication mockAuth = mock(Authentication.class);
+    when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+    when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+    when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+    when(mockUserService.userExists(email)).thenReturn(true);
+    when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.FACULTY);
 
-        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+    ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
-        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-        assertEquals(expectedResponse, response.getBody());
-    }
+    assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    assertEquals(
+        expectedResponse.get("isAuthenticated"),
+        Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+    assertEquals(expectedResponse, response.getBody());
+  }
 
-    @SuppressWarnings("null")
-    @Test
-    void testCheckAuthStatus_AuthenticatedNoRole() {
-        Map<String, String> expectedResponse = Map.of(
-                "isAuthenticated", "true",
-                "isStudent", "false",
-                "isFaculty", "false",
-                "isAdmin", "false"
-        );
+  @SuppressWarnings("null")
+  @Test
+  void testCheckAuthStatus_AuthenticatedNoRole() {
+    Map<String, String> expectedResponse =
+        Map.of(
+            "isAuthenticated", "true",
+            "isStudent", "false",
+            "isFaculty", "false",
+            "isAdmin", "false");
 
-        String email = "test@sandiego.edu";
-        Authentication mockAuth = mock(Authentication.class);
-        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
-        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
-        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
-        when(mockUserService.userExists(email)).thenReturn(false);
-        when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.STUDENT);
+    String email = "test@sandiego.edu";
+    Authentication mockAuth = mock(Authentication.class);
+    when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+    when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+    when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+    when(mockUserService.userExists(email)).thenReturn(false);
+    when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.STUDENT);
 
-        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+    ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
 
-        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-        assertEquals(expectedResponse, response.getBody());
-    }
+    assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    assertEquals(
+        expectedResponse.get("isAuthenticated"),
+        Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+    assertEquals(expectedResponse, response.getBody());
+  }
 
-    // @SuppressWarnings("null") // added because if response.getBody().get(...) returns null, the test should fail
-    // @Test
-    // void testCheckAuthStatus_AuthenticatedAdmin() {
-        // Map<String, String> expectedResponse = Map.of(
-        //         "isAuthenticated", "true",
-        //         "isStudent", "false",
-        //         "isFaculty", "false",
-        //         "isAdmin", "true"
-        // );
+  @SuppressWarnings(
+      "null") // added because if response.getBody().get(...) returns null, the test should fail
+  @Test
+  void testCheckAuthStatus_AuthenticatedAdmin() {
+    Map<String, String> expectedResponse =
+        Map.of(
+            "isAuthenticated", "true",
+            "isStudent", "false",
+            "isFaculty", "false",
+            "isAdmin", "true");
 
-        // TODO once method to get user role from DB is implemented
-//        Authentication mockAuth = mock(Authentication.class);
-//        when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
-//        when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
-//        when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn("test@admin.example.com");
-//
-//        ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
-//
-//        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-//        assertEquals(expectedResponse.get("isAuthenticated"), Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
-//        assertEquals(expectedResponse, response.getBody());
-    // }
+    String email = "test@admin.example.edu";
+    Authentication mockAuth = mock(Authentication.class);
+    when(mockOAuthChecker.getDefaultResponse()).thenReturn(expectedResponse);
+    when(mockOAuthChecker.isAuthenticated(mockAuth)).thenReturn(true);
+    when(mockOAuthChecker.getAuthUserEmail(mockAuth)).thenReturn(email);
+    when(mockUserService.getUserRoleByEmail(email)).thenReturn(UserRole.ADMIN);
+
+    ResponseEntity<Map<String, String>> response = authController.checkAuthStatus();
+
+    assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+    assertEquals(
+        expectedResponse.get("isAuthenticated"),
+        Objects.requireNonNull(response.getBody()).get("isAuthenticated"));
+    assertEquals(expectedResponse, response.getBody());
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature / Refactoring

**Summary:** Added new `UserRole` enum: `ADMIN` to allow the backend to tell the frontend that a user is an admin.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

- The `user_role` column in the `users` table now supports `ADMIN` to be a value.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

1. Make sure you have valid admin user data in the `users` table 
2. Log in through the frontend
3. Make sure the backend returns true for isAdmin
