### PR TITLE
disabled admin's ability to edit faculty email

### DIFF
--- a/frontend/src/components/admin/AdminFacultyEdit.js
+++ b/frontend/src/components/admin/AdminFacultyEdit.js
@@ -180,7 +180,7 @@ const AdminFacultyEdit = () => {
           type='email'
           value={formData.email}
           onChange={handleChange}
-          required
+          disabled
         />
         <FormControl fullWidth required>
           <InputLabel id='department-label'>Department</InputLabel>


### PR DESCRIPTION
# Overview

**Type of Change:**  Bug Fix

**Summary:** On form for admin to edit faculty email, I changed the email field from `required` to `disabled` so they cannot edit the faculty's email address.

## End-to-End Testing Instructions
1. login as admin
2. view a faculty profile
3. click edit
4. cannot edit the email
5. submit other edits to name and departments should work just fine