### PR TITLE
Implemented editUmbrellaTopic endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UmbrellaTopicService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UmbrellaTopicService.java
@@ -36,4 +36,13 @@ public class UmbrellaTopicService {
     public Optional<UmbrellaTopic> getUmbrellaTopicByName(String name) {
         return umbrellaTopicRepository.findUmbrellaTopicByName(name);
     }
+
+    public UmbrellaTopic getUmbrellaTopicById(int id) {
+        return umbrellaTopicRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Umbrella topic not found with id: " + id));
+    }
+
+    public UmbrellaTopic saveUmbrellaTopic(UmbrellaTopic umbrellaTopic) {
+        return umbrellaTopicRepository.save(umbrellaTopic);
+    }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -15,6 +15,7 @@ package COMP_49X_our_search.backend.gateway;
 import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoFacultyToFacultyDto;
 import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoStudentToStudentDto;
 import COMP_49X_our_search.backend.authentication.OAuthChecker;
+import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
 import COMP_49X_our_search.backend.database.services.*;
 import COMP_49X_our_search.backend.gateway.dto.CreateFacultyRequestDTO;
 import COMP_49X_our_search.backend.gateway.dto.CreateStudentRequestDTO;
@@ -407,6 +408,27 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Collections.emptyList());
     }
   }
+
+  @PutMapping("/umbrella-topic")
+  public ResponseEntity<UmbrellaTopicDTO> editUmbrellaTopic(
+          @RequestBody UmbrellaTopicDTO topicToUpdate) {
+    try {
+      UmbrellaTopic existing = umbrellaTopicService.getUmbrellaTopicById(topicToUpdate.getId());
+      existing.setName(topicToUpdate.getName());
+
+      UmbrellaTopic saved = umbrellaTopicService.saveUmbrellaTopic(existing);
+
+      UmbrellaTopicDTO updatedDto = new UmbrellaTopicDTO(saved.getId(), saved.getName());
+      return ResponseEntity.ok(updatedDto);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      return ResponseEntity
+              .status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .build();
+    }
+  }
+
 
   @PutMapping("/api/facultyProfiles/current")
   public ResponseEntity<FacultyDTO> editFacultyProfile(

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/UmbrellaTopicServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/UmbrellaTopicServiceTest.java
@@ -1,7 +1,6 @@
 package COMP_49X_our_search.backend.database;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
@@ -60,5 +59,37 @@ public class UmbrellaTopicServiceTest {
     Optional<UmbrellaTopic> result = service.getUmbrellaTopicByName("nonexistent");
 
     assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testGetUmbrellaTopicById_existingTopic_returnsTopic() {
+    UmbrellaTopic sampleTopic = new UmbrellaTopic(1, "AI");
+    when(umbrellaTopicRepository.findById(1)).thenReturn(Optional.of(sampleTopic));
+
+    UmbrellaTopic result = service.getUmbrellaTopicById(1);
+
+    assertEquals(sampleTopic, result);
+  }
+
+  @Test
+  void testGetUmbrellaTopicById_nonExistingTopic_throwsException() {
+    when(umbrellaTopicRepository.findById(2)).thenReturn(Optional.empty());
+
+    RuntimeException thrown =
+            assertThrows(RuntimeException.class, () -> service.getUmbrellaTopicById(2));
+
+    assertEquals("Umbrella topic not found with id: 2", thrown.getMessage());
+  }
+
+  @Test
+  void testSaveUmbrellaTopic() {
+    UmbrellaTopic newTopic = new UmbrellaTopic(0, "New Topic");
+    UmbrellaTopic savedTopic = new UmbrellaTopic(1, "New Topic");
+
+    when(umbrellaTopicRepository.save(newTopic)).thenReturn(savedTopic);
+
+    UmbrellaTopic result = service.saveUmbrellaTopic(newTopic);
+
+    assertEquals(savedTopic, result);
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -964,4 +964,30 @@ public class GatewayControllerTest {
             .andExpect(jsonPath("$.researchFieldInterests[0]").value("Computer Science"))
             .andExpect(jsonPath("$.researchPeriodsInterest[0]").value("Fall 2025"));
   }
+
+  @Test
+  @WithMockUser
+  void editUmbrellaTopic_returnsExpectedResult() throws Exception {
+    UmbrellaTopic existingTopic = new UmbrellaTopic();
+    existingTopic.setId(1);
+    existingTopic.setName("Old Name");
+
+    UmbrellaTopic updatedTopic = new UmbrellaTopic();
+    updatedTopic.setId(1);
+    updatedTopic.setName("New Name");
+
+    when(umbrellaTopicService.getUmbrellaTopicById(1)).thenReturn(existingTopic);
+    when(umbrellaTopicService.saveUmbrellaTopic(any(UmbrellaTopic.class)))
+            .thenReturn(updatedTopic);
+
+    UmbrellaTopicDTO requestDTO = new UmbrellaTopicDTO(1, "New Name");
+
+    mockMvc.perform(
+                    put("/umbrella-topic")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("New Name"));
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Implementation

**Summary:** Added `PUT` mapping at `/umbrellaTopic` endpoint a specific umbrellaTopic by its id.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added additional methods in the jpa umbrellaTopic services. 

## End-to-End Testing Instructions

-Make sure the frontend app, backend app, and the mysql database are running and that there is valid umbrella topic.
-Send 'PUT' request to the endpoint and verify the response is as expected, and that the umbrella topics were successfully changed.
