### PR TITLE
Bug fix: students and faculty to not see options to edit and delete posts

### DIFF
--- a/frontend/src/__tests__/posts/PostDialog.test.js
+++ b/frontend/src/__tests__/posts/PostDialog.test.js
@@ -86,6 +86,22 @@ describe('PostDialog Component', () => {
         expect(majorRefs.length).toBeGreaterThan(0)
       })
     })
+
+    it('does NOT edit and delete buttons for project', () => {
+      renderWithTheme(
+        <PostDialog
+          onClose={() => {}}
+          post={mockOneActiveProject}
+          isStudent
+          isFaculty={false}
+          isAdmin={false}
+          postsView={viewProjectsFlag}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: /edit project/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /delete project/i })).not.toBeInTheDocument()
+    })
   })
 
   describe('when user is faculty', () => {
@@ -131,6 +147,36 @@ describe('PostDialog Component', () => {
         const majorRefs = screen.getAllByText(new RegExp(major, 'i'))
         expect(majorRefs.length).toBeGreaterThan(0)
       })
+    })
+    it('does NOT edit and delete buttons for project', () => {
+      renderWithTheme(
+        <PostDialog
+          onClose={() => {}}
+          post={mockOneActiveProject}
+          isStudent={false}
+          isFaculty
+          isAdmin={false}
+          postsView={viewProjectsFlag}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: /edit project/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /delete project/i })).not.toBeInTheDocument()
+    })
+    it('does NOT redner edit and delete buttons for student', () => {
+      renderWithTheme(
+        <PostDialog
+          onClose={() => {}}
+          post={mockOneStudent}
+          isStudent={false}
+          isFaculty
+          isAdmin={false}
+          postsView={viewStudentsFlag}
+        />
+      )
+
+      expect(screen.queryByRole('button', { name: /edit profile/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /delete profile/i })).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -208,21 +208,26 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView })
             }}
           >
 
-            <Button
-              variant='outlined'
-              color='primary'
-              onClick={() => { navigate(`/project/${id}`) }}
-            >
-              Edit Project
-            </Button>
+            {isAdmin && (
+              <>
+                <Button
+                  variant='outlined'
+                  color='primary'
+                  onClick={() => { navigate(`/project/${id}`) }}
+                >
+                  Edit Project
+                </Button>
 
-            <Button
-              variant='outlined'
-              color='error'
-              onClick={() => setOpenDeleteDialog(true)}
-            >
-              Delete Project
-            </Button>
+                <Button
+                  variant='outlined'
+                  color='error'
+                  onClick={() => setOpenDeleteDialog(true)}
+                >
+                  Delete Project
+                </Button>
+              </>
+            )}
+
           </Box>
         </DialogTheme>
 
@@ -316,21 +321,25 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView })
             }}
           >
 
-            <Button
-              variant='outlined'
-              color='primary'
-              onClick={() => { navigate(`/student/${id}`) }}
-            >
-              Edit Profile
-            </Button>
+            {isAdmin && (
+              <>
+                <Button
+                  variant='outlined'
+                  color='primary'
+                  onClick={() => { navigate(`/student/${id}`) }}
+                >
+                  Edit Profile
+                </Button>
 
-            <Button
-              variant='outlined'
-              color='error'
-              onClick={() => setOpenDeleteDialog(true)}
-            >
-              Delete Profile
-            </Button>
+                <Button
+                  variant='outlined'
+                  color='error'
+                  onClick={() => setOpenDeleteDialog(true)}
+                >
+                  Delete Profile
+                </Button>
+              </>
+            )}
           </Box>
         </DialogTheme>
 
@@ -469,21 +478,25 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView })
             }}
           >
 
-            <Button
-              variant='outlined'
-              color='primary'
-              onClick={() => { navigate(`/faculty/${id}`) }}
-            >
-              Edit Profile
-            </Button>
+            {isAdmin && (
+              <>
+                <Button
+                  variant='outlined'
+                  color='primary'
+                  onClick={() => { navigate(`/faculty/${id}`) }}
+                >
+                  Edit Profile
+                </Button>
 
-            <Button
-              variant='outlined'
-              color='error'
-              onClick={() => setOpenDeleteDialog(true)}
-            >
-              Delete Profile
-            </Button>
+                <Button
+                  variant='outlined'
+                  color='error'
+                  onClick={() => setOpenDeleteDialog(true)}
+                >
+                  Delete Profile
+                </Button>
+              </>
+            )}
           </Box>
         </DialogTheme>
 


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** I had initially forgotten to only render the "edit profile/project" and "delete profile/project" buttons for only faculty. Now that is fixed.

## UI/UX Implementation
https://www.figma.com/design/Ek8pc7TK5PKx4eI3i4C78G/Sprint-4?node-id=0-1&p=f&t=QlPDUOcKwqZO137V-0

## End-to-End Testing Instructions
1. login as student or faculty, view posts, no edit or delete buttons
2. login as faculty, view posts, see edit and delete buttons