### PR TITLE
Modified compose.yaml to pull latest prebuilt images

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,16 +14,14 @@ services:
       retries: 5
 
   frontend:
-    build:
-      context: ./frontend
+    image: natjungquist/oursearch-frontend:latest
     ports:
       - "3000:80"
     depends_on:
       - backend # Wait for backend service to start
 
   backend:
-    build:
-      context: ./backend
+    image: natjungquist/oursearch-backend:latest
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
# Overview

**Type of Change:** Other

**Summary:** `compose.yaml` now pulls from images in my docker hub's image repositories. This is so that we can prebuild the images on our local machines before pushing to our Digital Ocean droplets. The droplets did not have enough RAM to build the images, so our solution to making deployment work is to prebuild the images so that `docker compose up` only has to pull them. 

## End-to-End Testing Instructions
1. in the root directory of this project, run `docker compose up`. It should pull the images from my repositories and build the project in a matter of seconds. The built images are the latest as of today, 3/27/25 at 9pm.