### PR TITLE
Implemented delete specific department endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
@@ -24,10 +24,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class DepartmentService {
 
   private final DepartmentRepository departmentRepository;
+  private final FacultyService facultyService;
 
   @Autowired
-  public DepartmentService(DepartmentRepository departmentRepository) {
+  public DepartmentService(DepartmentRepository departmentRepository, FacultyService facultyService) {
     this.departmentRepository = departmentRepository;
+    this.facultyService = facultyService;
   }
 
   public List<Department> getAllDepartments() {
@@ -39,12 +41,20 @@ public class DepartmentService {
   }
 
   @Transactional
-  public  void deleteByDepartmentId(int id) {
+  public void deleteByDepartmentId(int id) {
     if (!departmentRepository.existsById(id)) {
-      throw new RuntimeException(
-          String.format("Cannot delete department with id %s. Department not found", id)
-      );
+        throw new RuntimeException(
+            String.format("Cannot delete department with id %s. Department not found", id)
+        );
     }
+
+    facultyService.getFacultyByDepartmentId(id)
+        .forEach(faculty -> {
+            faculty.getDepartments().removeIf(department -> department.getId() == id);
+            facultyService.saveFaculty(faculty);
+        });
+    
+
     departmentRepository.deleteById(id);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class DepartmentService {
@@ -35,5 +36,15 @@ public class DepartmentService {
 
   public Optional<Department> getDepartmentByName(String name) {
     return departmentRepository.findDepartmentByName(name);
+  }
+
+  @Transactional
+  public  void deleteByDepartmentId(int id) {
+    if (!departmentRepository.existsById(id)) {
+      throw new RuntimeException(
+          String.format("Cannot delete faculty with id %s. Faculty not found", id)
+      );
+    }
+    departmentRepository.deleteById(id);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
@@ -53,7 +53,6 @@ public class DepartmentService {
             faculty.getDepartments().removeIf(department -> department.getId() == id);
             facultyService.saveFaculty(faculty);
         });
-    
 
     departmentRepository.deleteById(id);
   }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DepartmentService.java
@@ -42,7 +42,7 @@ public class DepartmentService {
   public  void deleteByDepartmentId(int id) {
     if (!departmentRepository.existsById(id)) {
       throw new RuntimeException(
-          String.format("Cannot delete faculty with id %s. Faculty not found", id)
+          String.format("Cannot delete department with id %s. Department not found", id)
       );
     }
     departmentRepository.deleteById(id);

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -843,4 +843,14 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
+
+  @DeleteMapping("/department")
+  public ResponseEntity<Void> deleteDepartment(@RequestBody DeleteRequestDTO requestBody) {
+    try {
+      departmentService.deleteByDepartmentId(requestBody.getId());
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/DepartmentServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/DepartmentServiceTest.java
@@ -7,6 +7,7 @@ import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.repositories.DepartmentRepository;
 import COMP_49X_our_search.backend.database.services.DepartmentService;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,11 +20,9 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 public class DepartmentServiceTest {
 
-  @Autowired
-  private DepartmentService departmentService;
+  @Autowired private DepartmentService departmentService;
 
-  @MockBean
-  private DepartmentRepository departmentRepository;
+  @MockBean private DepartmentRepository departmentRepository;
 
   @Test
   void testGetAllDepartments_returnsCorrectSize() {
@@ -31,12 +30,60 @@ public class DepartmentServiceTest {
     Department lifeSciencesDepartment = new Department("Life Sciences");
 
     Mockito.when(departmentRepository.findAll(Sort.by(Sort.Direction.ASC, "name")))
-            .thenReturn(List.of(engineeringDepartment, lifeSciencesDepartment));
+        .thenReturn(List.of(engineeringDepartment, lifeSciencesDepartment));
 
     List<Department> departments = departmentService.getAllDepartments();
 
     assertEquals(2, departments.size());
-    assertTrue(departments
-        .containsAll(List.of(engineeringDepartment, lifeSciencesDepartment)));
+    assertTrue(departments.containsAll(List.of(engineeringDepartment, lifeSciencesDepartment)));
+  }
+
+  @Test
+  void testGetDepartmentByName_returnsCorrectDepartment() {
+    Department csDepartment = new Department("Computer Science");
+
+    Mockito.when(departmentRepository.findDepartmentByName("Computer Science"))
+        .thenReturn(Optional.of(csDepartment));
+
+    Optional<Department> result = departmentService.getDepartmentByName("Computer Science");
+
+    assertTrue(result.isPresent());
+    assertEquals("Computer Science", result.get().getName());
+  }
+
+  @Test
+  void testGetDepartmentByName_returnsEmptyOptionalIfNotFound() {
+    Mockito.when(departmentRepository.findDepartmentByName("Nonexistent"))
+        .thenReturn(Optional.empty());
+
+    Optional<Department> result = departmentService.getDepartmentByName("Nonexistent");
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testDeleteByDepartmentId_deletesSuccessfullyIfExists() {
+    int deptId = 1;
+
+    Mockito.when(departmentRepository.existsById(deptId)).thenReturn(true);
+    Mockito.doNothing().when(departmentRepository).deleteById(deptId);
+
+    departmentService.deleteByDepartmentId(deptId);
+
+    Mockito.verify(departmentRepository).deleteById(deptId);
+  }
+
+  @Test
+  void testDeleteByDepartmentId_throwsExceptionIfNotFound() {
+    int deptId = 999;
+
+    Mockito.when(departmentRepository.existsById(deptId)).thenReturn(false);
+
+    RuntimeException exception =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            RuntimeException.class, () -> departmentService.deleteByDepartmentId(deptId));
+
+    assertEquals("Cannot delete faculty with id 999. Faculty not found", exception.getMessage());
+    Mockito.verify(departmentRepository, Mockito.never()).deleteById(deptId);
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1169,4 +1169,21 @@ public class GatewayControllerTest {
 
     verify(disciplineService, times(1)).deleteDisciplineById(1);
   }
+
+  @Test
+  @WithMockUser
+  void deleteDepartment_returnsExpectedResult() throws Exception {
+    DeleteRequestDTO deleteRequestDTO = new DeleteRequestDTO();
+    deleteRequestDTO.setId(1);
+
+    doNothing().when(departmentService).deleteByDepartmentId(1);
+
+    mockMvc
+        .perform(delete("/department")
+            .contentType("application/json")
+            .content(objectMapper.writeValueAsString(deleteRequestDTO)))
+        .andExpect(status().isOk());
+
+    verify(departmentService, times(1)).deleteByDepartmentId(1);
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New feature

**Summary:** Added `DELETE` mapping at `/department` endpoint to delete a specific department by its id.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added additional method in the jpa DepartmentService class to support the needed operations. 

## End-to-End Testing Instructions

1. Make sure the frontend app, the backend app, and the mysql database are running and that there is valid department data in the database.
2. Send `DELETE` request to endpoint `https://localhost:8080/department` including the id of the department in the request body and verify that the response is as expected, and that the department was successfully deleted.
