### PR TITLE
Implemented endpoint to edit Discipline

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
@@ -56,4 +56,13 @@ public class DisciplineService {
 
     disciplineRepository.delete(discipline);
   }
+
+  public Discipline getDisciplineById(int id) {
+    return disciplineRepository.findById(id)
+            .orElseThrow(() -> new RuntimeException("Discipline not found with id: " + id));
+  }
+
+  public Discipline saveDiscipline(Discipline discipline) {
+    return disciplineRepository.save(discipline);
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -952,4 +952,5 @@ public class GatewayController {
       e.printStackTrace();
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -872,9 +872,10 @@ public class GatewayController {
       Discipline discipline = disciplineService.getDisciplineById(requestBody.getId());
 
       if (requestBody.getName().isEmpty()) {
-      return ResponseEntity.badRequest().build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
       }
-      discipline.setName(newName);
+
+      discipline.setName(requestBody.getName());
 
       Discipline savedDiscipline = disciplineService.saveDiscipline(discipline);
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -865,4 +865,30 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
+
+  @PutMapping("/discipline")
+  public ResponseEntity<DisciplineDTO> editDiscipline(@RequestBody DisciplineDTO requestBody) {
+    try {
+      Discipline discipline = disciplineService.getDisciplineById(requestBody.getId());
+
+      String newName = requestBody.getName().isEmpty() ? discipline.getName() : requestBody.getName();
+      discipline.setName(newName);
+
+      Discipline savedDiscipline = disciplineService.saveDiscipline(discipline);
+
+      DisciplineDTO updatedDto = new DisciplineDTO(
+              savedDiscipline.getId(),
+              savedDiscipline.getName(),
+              majorService.getMajorsByDisciplineId(savedDiscipline.getId()).stream()
+                      .map(major -> new MajorDTO(major.getId(), major.getName()))
+                      .toList()
+      );
+
+      return ResponseEntity.ok(updatedDto);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -871,7 +871,9 @@ public class GatewayController {
     try {
       Discipline discipline = disciplineService.getDisciplineById(requestBody.getId());
 
-      String newName = requestBody.getName().isEmpty() ? discipline.getName() : requestBody.getName();
+      if (requestBody.getName().isEmpty()) {
+      return ResponseEntity.badRequest().build();
+      }
       discipline.setName(newName);
 
       Discipline savedDiscipline = disciplineService.saveDiscipline(discipline);

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
@@ -168,4 +168,34 @@ public class DisciplineServiceTest {
     verify(studentRepository, never()).save(any(Student.class));
     verify(disciplineRepository, never()).save(any(Discipline.class));
   }
+
+  @Test
+  void testGetDisciplineById_whenDisciplineDoesNotExist_throwsRuntimeException() {
+    // GIVEN
+    int disciplineId = 999;
+    when(disciplineRepository.findById(disciplineId)).thenReturn(Optional.empty());
+
+    // WHEN & THEN
+    RuntimeException ex = assertThrows(RuntimeException.class, () ->
+            disciplineService.getDisciplineById(disciplineId)
+    );
+
+    assertTrue(ex.getMessage().contains("Discipline not found with id: 999"));
+    verify(disciplineRepository, times(1)).findById(disciplineId);
+  }
+
+  @Test
+  void testSaveDiscipline_savesDisciplineAndReturnsIt() {
+    Discipline newDiscipline = new Discipline("Robotics");
+    Discipline savedDiscipline = new Discipline(1, "Robotics");
+
+    when(disciplineRepository.save(newDiscipline)).thenReturn(savedDiscipline);
+
+    Discipline result = disciplineService.saveDiscipline(newDiscipline);
+
+    assertEquals(savedDiscipline, result);
+    assertEquals(1, result.getId());
+    assertEquals("Robotics", result.getName());
+    verify(disciplineRepository, times(1)).save(newDiscipline);
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1195,4 +1195,39 @@ public class GatewayControllerTest {
 
     verify(disciplineService, times(1)).deleteDisciplineById(1);
   }
+
+  @Test
+  @WithMockUser
+  void editDiscipline_returnsExpectedResult() throws Exception {
+    Discipline existingDiscipline = new Discipline(1, "Old Name");
+
+    Discipline updatedDiscipline = new Discipline(1, "New Name");
+
+    Major major1 = new Major(10, "Computer Science");
+    Major major2 = new Major(20, "Math");
+
+    DisciplineDTO requestDTO = new DisciplineDTO(1, "New Name", null);
+
+    when(disciplineService.getDisciplineById(1)).thenReturn(existingDiscipline);
+    when(disciplineService.saveDiscipline(any(Discipline.class))).thenReturn(updatedDiscipline);
+    when(majorService.getMajorsByDisciplineId(1)).thenReturn(List.of(major1, major2));
+
+    mockMvc.perform(
+                    put("/discipline")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO))
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("New Name"))
+            .andExpect(jsonPath("$.majors.length()").value(2))
+            .andExpect(jsonPath("$.majors[0].id").value(10))
+            .andExpect(jsonPath("$.majors[0].name").value("Computer Science"))
+            .andExpect(jsonPath("$.majors[1].id").value(20))
+            .andExpect(jsonPath("$.majors[1].name").value("Math"));
+
+    verify(disciplineService, times(1)).getDisciplineById(1);
+    verify(disciplineService, times(1)).saveDiscipline(any(Discipline.class));
+    verify(majorService, times(1)).getMajorsByDisciplineId(1);
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Implementation

**Summary:** Added a PUT mapping at /discipline to update a specific Discipline by its ID.

## UI/UX Implementation

No changes made.

## Model Updates


### Data Models

No changes made.

### Object-Oriented Models

Added service methods for retrieving and saving Discipline entities in DisciplineService.

## End-to-End Testing Instructions

Ensure the system is running (frontend, backend, DB).

Confirm there’s an existing Discipline in the DB.

Send a PUT request with the Discipline ID and new name.

Check the response and database to confirm the name is updated.
