### PR TITLE
Implemented deleteSpecificUmbrella

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UmbrellaTopicService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UmbrellaTopicService.java
@@ -46,4 +46,8 @@ public class UmbrellaTopicService {
     public UmbrellaTopic saveUmbrellaTopic(UmbrellaTopic umbrellaTopic) {
         return umbrellaTopicRepository.save(umbrellaTopic);
     }
+
+    public void deleteUmbrellaTopicById(int id) {
+        umbrellaTopicRepository.deleteById(id);
+    }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -934,4 +934,5 @@ public class GatewayController {
       e.printStackTrace();
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -865,4 +865,15 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
+
+  @DeleteMapping("/umbrella-topic")
+  public ResponseEntity<Void> deleteUmbrellaTopic(@RequestBody DeleteRequestDTO requestBody) {
+    try {
+      umbrellaTopicService.deleteUmbrellaTopicById(requestBody.getId());
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      e.printStackTrace();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/UmbrellaTopicServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/UmbrellaTopicServiceTest.java
@@ -1,7 +1,7 @@
 package COMP_49X_our_search.backend.database;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import COMP_49X_our_search.backend.database.entities.UmbrellaTopic;
 import COMP_49X_our_search.backend.database.repositories.UmbrellaTopicRepository;
@@ -91,5 +91,30 @@ public class UmbrellaTopicServiceTest {
     UmbrellaTopic result = service.saveUmbrellaTopic(newTopic);
 
     assertEquals(savedTopic, result);
+  }
+
+  @Test
+  void testDeleteUmbrellaTopicById_success() {
+    int topicId = 1;
+
+    service.deleteUmbrellaTopicById(topicId);
+
+    verify(umbrellaTopicRepository, times(1)).deleteById(topicId);
+  }
+
+  @Test
+  void testDeleteUmbrellaTopicById_failure() {
+    int topicId = 1;
+
+    doThrow(new RuntimeException("Failed to delete umbrella topic"))
+            .when(umbrellaTopicRepository).deleteById(topicId);
+
+    RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            () -> service.deleteUmbrellaTopicById(topicId)
+    );
+
+    assertEquals("Failed to delete umbrella topic", thrown.getMessage());
+    verify(umbrellaTopicRepository, times(1)).deleteById(topicId);
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1195,4 +1195,21 @@ public class GatewayControllerTest {
 
     verify(disciplineService, times(1)).deleteDisciplineById(1);
   }
+
+  @Test
+  @WithMockUser
+  void deleteUmbrellaTopic_returnsExpectedResult() throws Exception {
+    DeleteRequestDTO deleteRequestDTO = new DeleteRequestDTO();
+    deleteRequestDTO.setId(1);
+
+    doNothing().when(umbrellaTopicService).deleteUmbrellaTopicById(1);
+
+    mockMvc.perform(
+                    delete("/umbrella-topic")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(deleteRequestDTO)))
+            .andExpect(status().isOk());
+
+    verify(umbrellaTopicService, times(1)).deleteUmbrellaTopicById(1);
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Implementation

**Summary:** Added a DELETE endpoint at /umbrella-topic to remove a specific umbrella topic by its ID.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

Added a delete method in the umbrella topic service and integrated it into the gateway controller.

## End-to-End Testing Instructions

 -Ensure the backend, frontend, and database are running.

 -Verify that an umbrella topic exists in the database.

 -Send a DELETE request to /umbrella-topic with the umbrella topic's ID in the payload.

 -Confirm that a 200 OK response is returned and the umbrella topic is removed from the database.
