### PR TITLE
Implemented Endpoint to create new discipline

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -1029,4 +1029,27 @@ public class GatewayController {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
+
+  @PostMapping("/discipline")
+  public ResponseEntity<DisciplineDTO> createDiscipline(@RequestBody DisciplineDTO disciplineDTO) {
+    try {
+      if (disciplineDTO.getName() == null || disciplineDTO.getName().trim().isEmpty()) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+      }
+      Discipline discipline = new Discipline();
+      discipline.setName(disciplineDTO.getName());
+
+      Discipline savedDiscipline = disciplineService.saveDiscipline(discipline);
+
+      List<MajorDTO> majorDTOs = majorService.getMajorsByDisciplineId(savedDiscipline.getId()).stream()
+              .map(major -> new MajorDTO(major.getId(), major.getName()))
+              .toList();
+      DisciplineDTO responseDTO = new DisciplineDTO(savedDiscipline.getId(), savedDiscipline.getName(), majorDTOs);
+
+      return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1451,4 +1451,56 @@ public class GatewayControllerTest {
   .andExpect(jsonPath("$.projects[0].researchPeriods").isArray())
   .andExpect(jsonPath("$.projects[0].researchPeriods", org.hamcrest.Matchers.hasItem("Fall 2025")));
   }
+
+  @Test
+  @WithMockUser
+  void createDiscipline_validRequest_returnsCreated() throws Exception {
+    DisciplineDTO requestDTO = new DisciplineDTO();
+    requestDTO.setName("Engineering");
+
+    Discipline savedDiscipline = new Discipline(1, "Engineering");
+    when(disciplineService.saveDiscipline(any(Discipline.class))).thenReturn(savedDiscipline);
+    when(majorService.getMajorsByDisciplineId(1)).thenReturn(List.of());
+
+    mockMvc.perform(
+                    post("/discipline")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("Engineering"))
+            .andExpect(jsonPath("$.majors.length()").value(0));
+
+    verify(disciplineService, times(1)).saveDiscipline(any(Discipline.class));
+    verify(majorService, times(1)).getMajorsByDisciplineId(1);
+  }
+
+  @Test
+  @WithMockUser
+  void createDiscipline_emptyName_returnsBadRequest() throws Exception {
+    DisciplineDTO requestDTO = new DisciplineDTO();
+    requestDTO.setName("  ");  // empty after trim
+
+    mockMvc.perform(
+                    post("/discipline")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser
+  void createDiscipline_serviceThrowsException_returnsInternalServerError() throws Exception {
+    DisciplineDTO requestDTO = new DisciplineDTO();
+    requestDTO.setName("Engineering");
+
+    when(disciplineService.saveDiscipline(any(Discipline.class)))
+            .thenThrow(new RuntimeException("DB error"));
+
+    mockMvc.perform(
+                    post("/discipline")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isInternalServerError());
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Added a new POST /discipline endpoint to create a discipline record. The endpoint validates the discipline name and returns the created discipline.

**Summary:** Added a DELETE endpoint at /umbrella-topic to remove a specific umbrella topic by its ID.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

Added a delete method in the umbrella topic service and integrated it into the gateway controller.

## End-to-End Testing Instructions

Ensure the backend, frontend, and database are running.

Verify that an umbrella topic exists in the database.

Send a DELETE request to /umbrella-topic with the umbrella topic's ID in the payload.