### PR TITLE
Implemented Endpoint to create new umbrella topic

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -1115,5 +1115,22 @@ public class GatewayController {
         case 5: return "Graduate";
         default: throw new IllegalArgumentException("Invalid class status: " + status);
     }
-}
+  }
+
+  @PostMapping("/umbrella-topic")
+  public ResponseEntity<UmbrellaTopicDTO> createUmbrellaTopic(@RequestBody UmbrellaTopicDTO requestBody) {
+    try {
+      if (requestBody.getName() == null || requestBody.getName().trim().isEmpty()) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+      }
+      UmbrellaTopic newTopic = new UmbrellaTopic();
+      newTopic.setName(requestBody.getName());
+      UmbrellaTopic savedTopic = umbrellaTopicService.saveUmbrellaTopic(newTopic);
+      UmbrellaTopicDTO createdDto = new UmbrellaTopicDTO(savedTopic.getId(), savedTopic.getName());
+      return ResponseEntity.status(HttpStatus.CREATED).body(createdDto);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1596,5 +1596,57 @@ void editResearchPeriod_returnsExpectedResult() throws Exception {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.id").value(periodId))
       .andExpect(jsonPath("$.name").value(newName));
-}
+  }
+
+  @Test
+  @WithMockUser
+  void createUmbrellaTopic_validRequest_returnsCreated() throws Exception {
+    UmbrellaTopicDTO requestDTO = new UmbrellaTopicDTO();
+    requestDTO.setName("Test Topic");
+
+    UmbrellaTopic savedTopic = new UmbrellaTopic();
+    savedTopic.setId(1);
+    savedTopic.setName("Test Topic");
+
+    when(umbrellaTopicService.saveUmbrellaTopic(any(UmbrellaTopic.class))).thenReturn(savedTopic);
+
+    mockMvc.perform(
+                    post("/umbrella-topic")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("Test Topic"));
+
+    verify(umbrellaTopicService, times(1)).saveUmbrellaTopic(any(UmbrellaTopic.class));
+  }
+
+  @Test
+  @WithMockUser
+  void createUmbrellaTopic_emptyName_returnsBadRequest() throws Exception {
+    UmbrellaTopicDTO requestDTO = new UmbrellaTopicDTO();
+    requestDTO.setName("   ");  // empty after trim
+
+    mockMvc.perform(
+                    post("/umbrella-topic")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser
+  void createUmbrellaTopic_serviceThrowsException_returnsInternalServerError() throws Exception {
+    UmbrellaTopicDTO requestDTO = new UmbrellaTopicDTO();
+    requestDTO.setName("Test Topic");
+
+    when(umbrellaTopicService.saveUmbrellaTopic(any(UmbrellaTopic.class)))
+            .thenThrow(new RuntimeException("DB error"));
+
+    mockMvc.perform(
+                    post("/umbrella-topic")
+                            .contentType("application/json")
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+            .andExpect(status().isInternalServerError());
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New feature.

**Summary:** Added a POST endpoint at /umbrella-topic to create new umbrella topics. Returns 201 on success and 400 if the name is empty.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

Added a save method in UmbrellaTopicService and updated the controller.

## End-to-End Testing Instructions

-Send a POST to umbrella topic
-Verify response
