### PR TITLE
frontend bug: admin functions did not include credentials

### DIFF
--- a/frontend/src/__tests__/admin/add/handleAddDepartment.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddDepartment.test.js
@@ -42,6 +42,7 @@ describe('handleAddDepartment', () => {
     await handleAddDepartment(newName, setNewDepartmentName, setDepartments, setLoadingDepartments, fetchDepartments, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/department'), {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newDepartmentName: newName })

--- a/frontend/src/__tests__/admin/add/handleAddDiscipline.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddDiscipline.test.js
@@ -44,6 +44,7 @@ describe('handleAddDiscipline', () => {
     await handleAddDiscipline(newDisciplineName, setNewDisciplineName, setDisciplines, prepopulateMajorsWithDisciplines, setLoadingDisciplinesMajors, fetchDisciplines, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/discipline'), {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newDisciplineName })

--- a/frontend/src/__tests__/admin/add/handleAddMajor.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddMajor.test.js
@@ -52,6 +52,7 @@ describe('handleAddMajor', () => {
     await handleAddMajor(newMajorName, setNewMajorName, newMajorDisciplines, setDisciplines, prepopulateMajorsWithDisciplines, setLoadingDisciplinesMajors, fetchDisciplines, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/major'), {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: newMajorName, disciplines: newMajorDisciplines })

--- a/frontend/src/__tests__/admin/add/handleAddPeriod.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddPeriod.test.js
@@ -43,6 +43,7 @@ describe('handleAddPeriod', () => {
     await handleAddPeriod(newPeriodName, setNewPeriodName, setResearchPeriods, setLoadingResearchPeriods, fetchResearchPeriods, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/research-period'), {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newPeriodName })

--- a/frontend/src/__tests__/admin/add/handleAddUmbrella.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddUmbrella.test.js
@@ -43,6 +43,7 @@ describe('handleAddUmbrella', () => {
     await handleAddUmbrella(newUmbrellaName, setNewUmbrellaName, setUmbrellaTopics, setLoadingUmbrellaTopics, fetchUmbrellaTopics, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/umbrella-topic'), {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newUmbrellaName })

--- a/frontend/src/__tests__/admin/delete/handleDeleteDepartment.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteDepartment.test.js
@@ -38,6 +38,7 @@ describe('handleDeleteDepartment', () => {
     await handleDeleteDepartment(1, setLoadingDepartments, departments, setDepartments, setDeletingIdDepartment, setOpenDeleteDialog, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/department'), {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1 })

--- a/frontend/src/__tests__/admin/delete/handleDeleteDiscipline.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteDiscipline.test.js
@@ -38,6 +38,7 @@ describe('handleDeleteDiscipline', () => {
     await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/discipline'), {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1 })

--- a/frontend/src/__tests__/admin/delete/handleDeleteMajor.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteMajor.test.js
@@ -38,6 +38,7 @@ describe('handleDeleteMajor', () => {
     await handleDeleteMajor(1, setLoadingDisciplinesMajors, majors, setMajors, setDeletingIdMajor, setOpenDeleteDialog, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/major'), {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1 })

--- a/frontend/src/__tests__/admin/delete/handleDeletePeriod.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeletePeriod.test.js
@@ -38,6 +38,7 @@ describe('handleDeletePeriod', () => {
     await handleDeletePeriod(1, setLoadingResearchPeriods, researchPeriods, setPeriods, setDeletingIdPeriod, setOpenDeleteDialog, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/research-period'), {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1 })

--- a/frontend/src/__tests__/admin/delete/handleDeleteUmbrella.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteUmbrella.test.js
@@ -38,6 +38,7 @@ describe('handleDeleteUmbrella', () => {
     await handleDeleteUmbrella(1, setLoadingUmbrellaTopics, umbrellaTopics, setUmbrellaTopics, setDeletingIdUmbrella, setOpenDeleteDialog, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/umbrella-topic'), {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1 })

--- a/frontend/src/__tests__/admin/edit/handleSaveDepartment.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveDepartment.test.js
@@ -20,6 +20,7 @@ describe('handleSaveDepartment', () => {
     await handleSaveDepartment(1, 'New Name', departments, setDepartments, setEditingIdDepartment, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/department'), {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/src/__tests__/admin/edit/handleSaveDiscipline.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveDiscipline.test.js
@@ -21,6 +21,7 @@ describe('handleSaveDiscipline', () => {
     await handleSaveDiscipline(1, editedNameDiscipline, disciplines, setDisciplines, setEditingIdDiscipline, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/discipline'), {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1, name: editedNameDiscipline })

--- a/frontend/src/__tests__/admin/edit/handleSaveMajor.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveMajor.test.js
@@ -32,6 +32,7 @@ describe('handleSaveMajor', () => {
     await handleSaveMajor(1, 'New Name', setEditingIdMajor, selectedDisciplines, majors, setMajors, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/major'), {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/src/__tests__/admin/edit/handleSavePeriod.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSavePeriod.test.js
@@ -21,6 +21,7 @@ describe('handleSavePeriod', () => {
     await handleSavePeriod(1, editedNamePeriod, setResearchPeriods, researchPeriods, setEditingIdPeriod, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/research-period'), {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1, name: editedNamePeriod })

--- a/frontend/src/__tests__/admin/edit/handleSaveUmbrella.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveUmbrella.test.js
@@ -21,6 +21,7 @@ describe('handleSaveUmbrella', () => {
     await handleSaveUmbrella(1, editedNameUmbrella, umbrellaTopics, setUmbrellaTopics, setEditingIdUmbrella, setError)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/umbrella-topic'), {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id: 1, name: editedNameUmbrella })

--- a/frontend/src/utils/adminFetching.js
+++ b/frontend/src/utils/adminFetching.js
@@ -23,6 +23,7 @@ export const handleSaveMajor = async (id, editedNameMajor, setEditingIdMajor, se
 
   try {
     const response = await fetch(`${backendUrl}/major?id=${id}`, {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -71,6 +72,7 @@ export const handleAddMajor = async (newMajorName, setNewMajorName, newMajorDisc
 
   try {
     const response = await fetch(`${backendUrl}/major`, {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(newMajor)
@@ -113,6 +115,7 @@ export const handleDeleteMajor = async (id, setLoadingDisciplinesMajors, majors,
 
   try {
     const response = await fetch(`${backendUrl}/major?id=${id}`, {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -145,6 +148,7 @@ export const handleDeleteMajor = async (id, setLoadingDisciplinesMajors, majors,
 export const handleSaveDiscipline = async (id, editedNameDiscipline, disciplines, setDisciplines, setEditingIdDiscipline, setError) => {
   try {
     const response = await fetch(`${backendUrl}/discipline?id=${id}`, {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -183,6 +187,7 @@ export const handleAddDiscipline = async (newDisciplineName, setNewDisciplineNam
 
   try {
     const response = await fetch(`${backendUrl}/discipline`, {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newDisciplineName })
@@ -225,6 +230,7 @@ export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, di
 
   try {
     const response = await fetch(`${backendUrl}/discipline?id=${id}`, {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -257,6 +263,7 @@ export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, di
 export const handleSaveUmbrella = async (id, editedNameUmbrella, umbrellaTopics, setUmbrellaTopics, setEditingIdUmbrella, setError) => {
   try {
     const response = await fetch(`${backendUrl}/umbrella-topic?id=${id}`, {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -295,6 +302,7 @@ export const handleAddUmbrella = async (newUmbrellaName, setNewUmbrellaName, set
 
   try {
     const response = await fetch(`${backendUrl}/umbrella-topic`, {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newUmbrellaName })
@@ -336,6 +344,7 @@ export const handleDeleteUmbrella = async (id, setLoadingUmbrellaTopics, umbrell
 
   try {
     const response = await fetch(`${backendUrl}/umbrella-topic?id=${id}`, {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -368,6 +377,7 @@ export const handleDeleteUmbrella = async (id, setLoadingUmbrellaTopics, umbrell
 export const handleSavePeriod = async (id, editedNamePeriod, setResearchPeriods, researchPeriods, setEditingIdPeriod, setError) => {
   try {
     const response = await fetch(`${backendUrl}/research-period?id=${id}`, {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -406,6 +416,7 @@ export const handleAddPeriod = async (newPeriodName, setNewPeriodName, setResear
 
   try {
     const response = await fetch(`${backendUrl}/research-period`, {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newPeriodName })
@@ -447,6 +458,7 @@ export const handleDeletePeriod = async (id, setLoadingResearchPeriods, research
 
   try {
     const response = await fetch(`${backendUrl}/research-period?id=${id}`, {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -479,6 +491,7 @@ export const handleDeletePeriod = async (id, setLoadingResearchPeriods, research
 export const handleSaveDepartment = async (id, editedNameDepartment, departments, setDepartments, setEditingIdDepartment, setError) => {
   try {
     const response = await fetch(`${backendUrl}/department?id=${id}`, {
+      credentials: 'include',
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -517,6 +530,7 @@ export const handleAddDepartment = async (newDepartmentName, setNewDepartmentNam
 
   try {
     const response = await fetch(`${backendUrl}/department`, {
+      credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ newDepartmentName })
@@ -558,6 +572,7 @@ export const handleDeleteDepartment = async (id, setLoadingDepartments, departme
 
   try {
     const response = await fetch(`${backendUrl}/department?id=${id}`, {
+      credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
# Overview

**Type of Change:** bug fix

**Summary:** admin functions to add, edit, and delete app variables did not have credentials: 'include' in fetch calls to backend. this is needed for authentication, otherwise the requests will not work. forgot to add this before