### PR TITLE
Admin feat to delete disciplines with no majors; control majors with no disciplines

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/MajorRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/MajorRepository.java
@@ -12,8 +12,11 @@ import COMP_49X_our_search.backend.database.entities.Major;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MajorRepository extends JpaRepository<Major, Integer> {
   List<Major> findAllByDisciplines_Id(Integer disciplineId);
   Optional<Major> findMajorByName(String name);
+  @Query("SELECT m FROM Major m WHERE m.disciplines IS EMPTY")
+  List<Major> findAllMajorsWithoutDisciplines();
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/MajorService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/MajorService.java
@@ -10,6 +10,7 @@ package COMP_49X_our_search.backend.database.services;
 
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.repositories.MajorRepository;
+
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,5 +66,9 @@ public class MajorService {
     }
 
     majorRepository.delete(major);
+  }
+
+  public List<Major> getMajorsWithoutDisciplines() {
+    return majorRepository.findAllMajorsWithoutDisciplines();
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -12,6 +12,7 @@
  */
 package COMP_49X_our_search.backend.gateway;
 
+import java.util.ArrayList;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -446,7 +447,13 @@ public class GatewayController {
                             .toList();
                     return new DisciplineDTO(discipline.getId(), discipline.getName(), majorDTOS);
                   })
-              .toList();
+                  .collect(Collectors.toCollection(ArrayList::new)); //list must be mutable so we can add emptyDiscipline after
+      
+      List<MajorDTO> majorsWithoutDisciplines = majorService.getMajorsWithoutDisciplines().stream()
+        .map(major -> new MajorDTO(major.getId(), major.getName()))
+        .toList();
+      DisciplineDTO emptyDiscipline = new DisciplineDTO(-1, "", majorsWithoutDisciplines);
+      disciplineDTOS.add(emptyDiscipline);
       return ResponseEntity.ok(disciplineDTOS);
     } catch (Exception e) {
       e.printStackTrace();

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/MajorServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/MajorServiceTest.java
@@ -2,6 +2,7 @@ package COMP_49X_our_search.backend.database;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -22,7 +23,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -183,5 +183,21 @@ public class MajorServiceTest {
 
     assertEquals("Major has projects associated with it, cannot delete", exception.getMessage());
     verify(majorRepository, never()).delete(any());
+  }
+
+  @Test
+  void testGetMajorsWithoutDisciplines() {
+    Major major1 = new Major(1, "Computer Science");
+    Major major2 = new Major(2, "Mathematics");
+    List<Major> mockMajors = List.of(major1, major2);
+    when(majorRepository.findAllMajorsWithoutDisciplines()).thenReturn(mockMajors);
+
+    List<Major> result = majorService.getMajorsWithoutDisciplines();
+
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertEquals("Computer Science", result.get(0).getName());
+    assertEquals("Mathematics", result.get(1).getName());
+    verify(majorRepository, times(1)).findAllMajorsWithoutDisciplines();
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -557,16 +557,19 @@ public class GatewayControllerTest {
     Major major1 = new Major(1, "Computer Science");
     Major major2 = new Major(2, "Math");
     Major major3 = new Major(3, "Drawing");
+    Major major4 = new Major(4, "I dont have a discipline");
     when(majorService.getMajorsByDisciplineId(discipline1.getId()))
         .thenReturn(List.of(major1, major2));
     when(majorService.getMajorsByDisciplineId(discipline2.getId())).thenReturn(List.of(major3));
+    when(majorService.getMajorsWithoutDisciplines()).thenReturn(List.of(major4));
 
     mockMvc
         .perform(get("/disciplines"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$.length()").value(3))
         .andExpect(jsonPath("$[0].id").value(discipline1.getId()))
         .andExpect(jsonPath("$[1].id").value(discipline2.getId()))
+        .andExpect(jsonPath("$[2].id").value(-1)) // add on -1 reference for majors with no disciplines
         .andExpect(jsonPath("$[0].name").value(discipline1.getName()))
         .andExpect(jsonPath("$[1].name").value(discipline2.getName()))
         .andExpect(jsonPath("$[0].majors.length()").value(2))
@@ -576,7 +579,8 @@ public class GatewayControllerTest {
         .andExpect(jsonPath("$[0].majors[1].name").value(major2.getName()))
         .andExpect(jsonPath("$[1].majors.length()").value(1))
         .andExpect(jsonPath("$[1].majors[0].id").value(major3.getId()))
-        .andExpect(jsonPath("$[1].majors[0].name").value(major3.getName()));
+        .andExpect(jsonPath("$[1].majors[0].name").value(major3.getName()))
+        .andExpect(jsonPath("$[2].majors[0].name").value(major4.getName()));
   }
 
   @Test

--- a/frontend/src/__tests__/admin/add/handleAddMajor.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddMajor.test.js
@@ -28,13 +28,6 @@ describe('handleAddMajor', () => {
     expect(setLoadingDisciplinesMajors).not.toHaveBeenCalled()
   })
 
-  it('should show an error if disciplines are not selected', async () => {
-    await handleAddMajor(newMajorName, setNewMajorName, [], setDisciplines, prepopulateMajorsWithDisciplines, setLoadingDisciplinesMajors, fetchDisciplines, setError)
-
-    expect(setError).toHaveBeenCalledWith('Error adding major. Must be under at least one discipline.')
-    expect(setLoadingDisciplinesMajors).not.toHaveBeenCalled()
-  })
-
   it('should set loading state while adding major', async () => {
     fetch.mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue([]) })
     fetchDisciplines.mockResolvedValue([{ id: 1, name: newMajorName, disciplines: newMajorDisciplines }])

--- a/frontend/src/__tests__/admin/delete/handleDeleteDiscipline.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteDiscipline.test.js
@@ -1,7 +1,7 @@
 import { handleDeleteDiscipline } from '../../../utils/adminFetching'
 
 describe('handleDeleteDiscipline', () => {
-  let setLoadingDisciplinesMajors, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, disciplines
+  let setLoadingDisciplinesMajors, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, disciplines, fetchDisciplines, prepopulateMajorsWithDisciplines
 
   beforeEach(() => {
     setLoadingDisciplinesMajors = jest.fn()
@@ -9,6 +9,8 @@ describe('handleDeleteDiscipline', () => {
     setDeletingIdDiscipline = jest.fn()
     setOpenDeleteDialog = jest.fn()
     setError = jest.fn()
+    fetchDisciplines = jest.fn()
+    prepopulateMajorsWithDisciplines = jest.fn()
 
     global.fetch = jest.fn()
 
@@ -26,7 +28,7 @@ describe('handleDeleteDiscipline', () => {
   it('should call setLoadingDisciplinesMajors(true) to set loading state while deleting discipline', async () => {
     fetch.mockResolvedValue({ ok: true })
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setLoadingDisciplinesMajors).toHaveBeenCalledWith(true)
     expect(setLoadingDisciplinesMajors).toHaveBeenCalledWith(false)
@@ -35,7 +37,7 @@ describe('handleDeleteDiscipline', () => {
   it('should make a DELETE request to delete the discipline', async () => {
     fetch.mockResolvedValue({ ok: true })
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/discipline'), {
       credentials: 'include',
@@ -46,20 +48,33 @@ describe('handleDeleteDiscipline', () => {
   })
 
   it('should update disciplines after successfully deleting the discipline', async () => {
-    fetch.mockResolvedValue({ ok: true })
+    fetch.mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue([]) })
+    const newDisciplines = [{ id: 1, name: 'Humanities', majors: [] }]
+    fetchDisciplines.mockResolvedValue(newDisciplines)
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
-    expect(setDisciplines).toHaveBeenCalledWith([{ id: 2, name: 'Arts' }])
+    expect(fetchDisciplines).toHaveBeenCalled()
+    expect(prepopulateMajorsWithDisciplines).toHaveBeenCalledWith(newDisciplines)
+    expect(setDisciplines).toHaveBeenCalledWith(newDisciplines)
     expect(setError).toHaveBeenCalledWith(null)
     expect(setDeletingIdDiscipline).toHaveBeenCalledWith(null)
     expect(setOpenDeleteDialog).toHaveBeenCalledWith(false)
   })
 
+  it('should set an error if fetchDisciplines returns an empty array', async () => {
+    fetch.mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue([]) })
+    fetchDisciplines.mockResolvedValue([])
+
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
+
+    expect(setError).toHaveBeenCalledWith('Discipline deleted, but there was an error loading updated disciplines and majors data.')
+  })
+
   it('should set error if the DELETE request is bad (400)', async () => {
     fetch.mockResolvedValue({ ok: false, status: 400 })
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setError).toHaveBeenCalledWith('Bad request.')
   })
@@ -67,7 +82,7 @@ describe('handleDeleteDiscipline', () => {
   it('should set error if discipline has connections (409)', async () => {
     fetch.mockResolvedValue({ ok: false, status: 409 })
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setError).toHaveBeenCalledWith('Life Sciences cannot be deleted because it has connections to other projects. Please edit or remove those connections first. Remove connections, then try again.')
   })
@@ -75,7 +90,7 @@ describe('handleDeleteDiscipline', () => {
   it('should set an error for unexpected errors', async () => {
     fetch.mockRejectedValue(new Error('Network error'))
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setError).toHaveBeenCalledWith('Unexpected error deleting discipline: Life Sciences.')
   })
@@ -83,19 +98,19 @@ describe('handleDeleteDiscipline', () => {
   it('should call setLoadingDisciplinesMajors(false) after succesful deletion', async () => {
     fetch.mockResolvedValue({ ok: true })
 
-    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setLoadingDisciplinesMajors).toHaveBeenCalledWith(false)
   })
 
   it('should NOT call setLoadingDisciplinesMajors(false) to keep loading if discipline not found', async () => {
-    await handleDeleteDiscipline(3, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(3, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setLoadingDisciplinesMajors).not.toHaveBeenCalledWith(false)
   })
 
   it('should set error message if discipline not found', async () => {
-    await handleDeleteDiscipline(3, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+    await handleDeleteDiscipline(3, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
 
     expect(setError).toHaveBeenCalledWith('Discipline not found.')
   })

--- a/frontend/src/__tests__/admin/edit/handleSaveDepartment.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveDepartment.test.js
@@ -12,6 +12,12 @@ describe('handleSaveDepartment', () => {
     global.fetch.mockClear()
   })
 
+  it('should show an error if name is empty', async () => {
+    await handleSaveDepartment(1, '', [], setDepartments, setEditingIdDepartment, setError)
+
+    expect(setError).toHaveBeenCalledWith('Error editing department. Must have a name.')
+  })
+
   it('should make a PUT request to save department', async () => {
     const departments = [{ id: 1, name: 'Old Name' }]
 

--- a/frontend/src/__tests__/admin/edit/handleSaveDiscipline.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveDiscipline.test.js
@@ -12,6 +12,12 @@ describe('handleSaveDiscipline', () => {
     global.fetch.mockClear()
   })
 
+  it('should show an error if name is empty', async () => {
+    await handleSaveDiscipline(1, ' ', [], setDisciplines, setEditingIdDiscipline, setError)
+
+    expect(setError).toHaveBeenCalledWith('Error editing discipline. Must have a name.')
+  })
+
   it('should make a PUT request to save discipline', async () => {
     const disciplines = [{ id: 1, name: 'Old Discipline' }]
     const editedNameDiscipline = 'New Discipline'

--- a/frontend/src/__tests__/admin/edit/handleSaveMajor.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveMajor.test.js
@@ -5,6 +5,11 @@ global.fetch = jest.fn()
 describe('handleSaveMajor', () => {
   let setEditingIdMajor, setMajors, setError
 
+  const selectedDisciplines = {
+    1: [{ id: 1, name: 'Science discipline', majors: [{ id: 1, name: 'Major' }] }], // mock that major with id 1 has 1 discipline
+    2: [] // mock that major with id 2 has no discipline
+  }
+
   beforeEach(() => {
     setEditingIdMajor = jest.fn()
     setMajors = jest.fn()
@@ -12,19 +17,13 @@ describe('handleSaveMajor', () => {
     global.fetch.mockClear()
   })
 
-  it('should return an error if no disciplines are selected', async () => {
-    const selectedDisciplines = { 1: [] }
+  it('should show an error if major name is empty', async () => {
+    await handleSaveMajor(1, '  ', setEditingIdMajor, [], [], setMajors, setError)
 
-    await handleSaveMajor(1, 'New Name', setEditingIdMajor, selectedDisciplines, [], setMajors, setError)
-
-    expect(setError).toHaveBeenCalledWith(
-      'You must associate this major with one or more disciplines. Please try again.'
-    )
-    expect(global.fetch).not.toHaveBeenCalled()
+    expect(setError).toHaveBeenCalledWith('Error editing major. Must have a name.')
   })
 
   it('should make a PUT request to save major', async () => {
-    const selectedDisciplines = { 1: [{ name: 'Science' }] }
     const majors = [{ id: 1, name: 'Old Name', disciplines: [] }]
 
     global.fetch.mockResolvedValue({ ok: true })
@@ -44,14 +43,25 @@ describe('handleSaveMajor', () => {
   })
 
   it('should update major successfully after successfully saving major', async () => {
-    const selectedDisciplines = { 1: [{ name: 'Science' }] }
-    const majors = [{ id: 1, name: 'Old Name', disciplines: [] }]
+    const majors = [{ id: 1, name: 'Old Name', disciplines: [selectedDisciplines[1][0]] }]
 
     global.fetch.mockResolvedValue({ ok: true })
 
     await handleSaveMajor(1, 'New Name', setEditingIdMajor, selectedDisciplines, majors, setMajors, setError)
 
-    expect(setMajors).toHaveBeenCalledWith([{ id: 1, name: 'New Name', disciplines: selectedDisciplines[1] }])
+    expect(setMajors).toHaveBeenCalledWith([{ id: 1, name: 'New Name', disciplines: [selectedDisciplines[1][0]] }])
+    expect(setError).toHaveBeenCalledWith(null)
+    expect(setEditingIdMajor).toHaveBeenCalledWith(null)
+  })
+
+  it('works to save major if no disciplines are selected', async () => {
+    const majors = [{ id: 2, name: 'Other Major', disciplines: [] }]
+
+    global.fetch.mockResolvedValue({ ok: true })
+
+    await handleSaveMajor(2, 'Other Major new name', setEditingIdMajor, selectedDisciplines, majors, setMajors, setError)
+
+    expect(setMajors).toHaveBeenCalledWith([{ id: 2, name: 'Other Major new name', disciplines: [] }])
     expect(setError).toHaveBeenCalledWith(null)
     expect(setEditingIdMajor).toHaveBeenCalledWith(null)
   })

--- a/frontend/src/__tests__/admin/edit/handleSavePeriod.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSavePeriod.test.js
@@ -12,6 +12,12 @@ describe('handleSavePeriod', () => {
     global.fetch.mockClear()
   })
 
+  it('should show an error if name is empty', async () => {
+    await handleSavePeriod(1, '  ', setResearchPeriods, [], setEditingIdPeriod, setError)
+
+    expect(setError).toHaveBeenCalledWith('Error editing research period. Must have a name.')
+  })
+
   it('should make a PUT request to save research period', async () => {
     const researchPeriods = [{ id: 1, name: 'Old Period' }]
     const editedNamePeriod = 'New Period'

--- a/frontend/src/__tests__/admin/edit/handleSaveUmbrella.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveUmbrella.test.js
@@ -12,6 +12,12 @@ describe('handleSaveUmbrella', () => {
     global.fetch.mockClear()
   })
 
+  it('should show an error if name is empty', async () => {
+    await handleSaveUmbrella(1, '', [], setUmbrellaTopics, setEditingIdUmbrella, setError)
+
+    expect(setError).toHaveBeenCalledWith('Error editing topic. Must have a name.')
+  })
+
   it('should make a PUT request to save umbrella topic', async () => {
     const umbrellaTopics = [{ id: 1, name: 'Old Umbrella' }]
     const editedNameUmbrella = 'New Umbrella'

--- a/frontend/src/__tests__/admin/view/ManageVariables.test.js
+++ b/frontend/src/__tests__/admin/view/ManageVariables.test.js
@@ -513,18 +513,6 @@ describe('ManageVariables', () => {
         expect(newMajorInput).toBeInTheDocument()
         expect(addButton).toBeInTheDocument()
       })
-      test('cannot add if not associated with a discipline', async () => {
-        renderWithTheme(<ManageVariables showingDisciplinesAndMajors />)
-        await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
-
-        const newMajorInput = screen.getByLabelText(/new major name/i)
-        const addButton = screen.getAllByTestId('add-major-btn')[0]
-
-        fireEvent.change(newMajorInput, { target: { value: 'Artificial Intelligence' } })
-        fireEvent.click(addButton)
-
-        expect(screen.getByText(/error adding major/i)).toBeInTheDocument()
-      })
     })
   })
 })

--- a/frontend/src/components/admin/AdminEmailNotification.js
+++ b/frontend/src/components/admin/AdminEmailNotification.js
@@ -115,7 +115,7 @@ const AdminEmailNotifications = () => {
     <Paper sx={{ maxWidth: 800, mx: 'auto', mt: 4, p: 3 }}>
       {/* Back button */}
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-        <Button variant='outlined' onClick={handleBack} sx={{ backgroundColor: 'lightblue', mr: 2 }}>
+        <Button variant='outlined' onClick={handleBack} sx={{ mr: 2 }}>
           Back
         </Button>
         <Box sx={{ flexGrow: 1, textAlign: 'center' }}>

--- a/frontend/src/components/admin/ManageVariables.js
+++ b/frontend/src/components/admin/ManageVariables.js
@@ -141,11 +141,18 @@ function ManageVariables ({
     })
 
     setMajors(Object.values(majorMap)) // converts values into an array
+    // with key: majorId, value: object containing major id, name, disciplines (array of discipline objects with id, name, majors)
+    // ex: { 1: { id: 1, name: 'major name', disciplines: [ {id, name, majors ...} ]}}
 
     // Prepopulate discipline selections per major
+    // key: majorId, value: object with disciplineId, disciplineName, list of majors
     const prepopulatedMajorDisciplines = {}
     Object.values(majorMap).forEach(major => {
-      prepopulatedMajorDisciplines[major.id] = major.disciplines
+      if (major.disciplines.length === 1 && major.disciplines[0].id === -1) { // (-1 is for majors with no discipline)
+        prepopulatedMajorDisciplines[major.id] = []
+      } else {
+        prepopulatedMajorDisciplines[major.id] = major.disciplines
+      }
     })
 
     setSelectedDisciplines(prepopulatedMajorDisciplines)
@@ -160,7 +167,6 @@ function ManageVariables ({
       let departmentsRes = []
       if (showingDisciplinesAndMajors) {
         disciplinesRes = await fetchDisciplines()
-        // disciplinesRes = mockDisciplinesMajors // TODO remove after testing
       }
       if (showingResearchPeriods) {
         researchPeriodsRes = await fetchResearchPeriods()
@@ -220,7 +226,7 @@ function ManageVariables ({
   const handleCancelMajorEdit = (id) => {
     setSelectedDisciplines(prev => ({ // Set the disciplines back to what they originally were
       ...prev,
-      [id]: majors.find(m => m.id === id)?.disciplines || []
+      [id]: majors.find(m => m.id === id)?.disciplines[0].id !== -1 ? majors.find(m => m.id === id)?.disciplines : [] // set selected disciplines to empty array if the major previously had no discipline (id was -1)
     }))
     setEditingIdMajor(null) // Stop editting this major
     setEditedNameMajor('')
@@ -318,7 +324,7 @@ function ManageVariables ({
   // uses deletingId to know which delete function to call on the shared AreYouSureDialog box
   const handleDelete = async () => {
     if (deletingIdDiscipline !== null) {
-      await handleDeleteDiscipline(deletingIdDiscipline, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError)
+      await handleDeleteDiscipline(deletingIdDiscipline, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
     }
     if (deletingIdMajor !== null) {
       await handleDeleteMajor(deletingIdMajor, setLoadingDisciplinesMajors, majors, setMajors, setDeletingIdMajor, setOpenDeleteDialog, setError)
@@ -345,10 +351,12 @@ function ManageVariables ({
   }
   return (
     <>
-      <Box display='flex' justifyContent='center' alignItems='center' flexDirection='column' sx={{ marginTop: 2 }}>
-        <Button variant='outlined' onClick={() => { navigate('/posts') }} sx={{ mb: 2 }}>
+      <Box sx={{ display: 'flex', margin: 3 }}>
+        <Button variant='outlined' onClick={() => { navigate('/posts') }} sx={{ mr: 2 }}>
           Back
         </Button>
+      </Box>
+      <Box display='flex' justifyContent='center' alignItems='center' flexDirection='column' sx={{ marginTop: 2 }}>
         <Typography variant='h2'>Manage App Variables</Typography>
         {error && (
           <Typography variant='body1' color='error' sx={{ marginTop: 2 }}>
@@ -357,9 +365,9 @@ function ManageVariables ({
         )}
 
       </Box>
-      <Box display='flex' sx={{ marginTop: 2 }}>
-        <InfoIcon />
+      <Box sx={{ padding: 2, maxWidth: 900, margin: 'auto' }}>
         <Typography variant='body1'>
+          <InfoIcon />
           Here you can manage the data included in the OUR SEARCH app.
           Instructions: Edit variable names, add new variables, and delete variables. Note that you cannot remove if there are projects, students, or faculty currently attached to it.
         </Typography>

--- a/frontend/src/components/admin/RenderAdminVariables.js
+++ b/frontend/src/components/admin/RenderAdminVariables.js
@@ -43,65 +43,67 @@ export const renderDisciplines = ({
     <Box sx={{ padding: 2, maxWidth: 900, margin: 'auto' }}>
       <Typography variant='h5' gutterBottom>Disciplines</Typography>
       <List>
-        {disciplines.map(({ id, name }) => (
-          <ListItem key={id} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 1 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', gap: editingIdDiscipline === id ? '10px' : '0px' }}>
+        {disciplines
+          .filter((disc) => disc.id !== -1)
+          .map(({ id, name }) => (
+            <ListItem key={id} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 1 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', gap: editingIdDiscipline === id ? '10px' : '0px' }}>
 
-              {/* Textbox, can edit once the edit button is clicked */}
-              {editingIdDiscipline === id
-                ? (
-                  <TextField
-                    defaultValue={name}
-                    onChange={(e) => setEditedNameDiscipline(e.target.value)}
-                    size='small'
-                    autoFocus
-                    sx={{ width: '35%' }}
-                  />
-                  )
-                : (
-                  <ListItemText primary={name} sx={{ width: '35%' }} />
+                {/* Textbox, can edit once the edit button is clicked */}
+                {editingIdDiscipline === id
+                  ? (
+                    <TextField
+                      defaultValue={name}
+                      onChange={(e) => setEditedNameDiscipline(e.target.value)}
+                      size='small'
+                      autoFocus
+                      sx={{ width: '35%' }}
+                    />
+                    )
+                  : (
+                    <ListItemText primary={name} sx={{ width: '35%' }} />
+                    )}
+
+                {/* Edit and Delete buttons */}
+                <div style={{ display: 'flex', gap: '5px' }}>
+                  {editingIdDiscipline !== id && (
+                    <>
+                      <IconButton onClick={() => handleEditDiscipline(id, name)} data-testid='edit-discipline-btn'>
+                        <Edit />
+                      </IconButton>
+
+                      <IconButton onClick={() => handleBeginDeleteDiscipline(id)} color='error' data-testid='delete-discipline-btn'>
+                        <Delete />
+                      </IconButton>
+                    </>
                   )}
 
-              {/* Edit and Delete buttons */}
-              <div style={{ display: 'flex', gap: '5px' }}>
-                {editingIdDiscipline !== id && (
-                  <>
-                    <IconButton onClick={() => handleEditDiscipline(id, name)} data-testid='edit-discipline-btn'>
-                      <Edit />
-                    </IconButton>
-
-                    <IconButton onClick={() => handleBeginDeleteDiscipline(id)} color='error' data-testid='delete-discipline-btn'>
-                      <Delete />
-                    </IconButton>
-                  </>
-                )}
-
+                </div>
               </div>
-            </div>
 
-            {/* Save and cancel buttons below */}
-            {editingIdDiscipline === id && (
-              <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, mt: 1, mb: 4 }}>
-                <Button
-                  variant='contained' color='primary'
-                  startIcon={<Save />}
-                  onClick={() => handleSaveDiscipline(id)}
-                  data-testid='save-discipline-btn'
-                >
-                  Save
-                </Button>
-                <Button
-                  variant='outlined' color='warning'
-                  startIcon={<Cancel />}
-                  onClick={() => handleCancelDisciplineEdit(id)}
-                  data-testid='cancel-discipline-btn'
-                >
-                  Cancel
-                </Button>
-              </Box>
-            )}
-          </ListItem>
-        ))}
+              {/* Save and cancel buttons below */}
+              {editingIdDiscipline === id && (
+                <Box sx={{ display: 'flex', justifyContent: 'center', gap: 2, mt: 1, mb: 4 }}>
+                  <Button
+                    variant='contained' color='primary'
+                    startIcon={<Save />}
+                    onClick={() => handleSaveDiscipline(id)}
+                    data-testid='save-discipline-btn'
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    variant='outlined' color='warning'
+                    startIcon={<Cancel />}
+                    onClick={() => handleCancelDisciplineEdit(id)}
+                    data-testid='cancel-discipline-btn'
+                  >
+                    Cancel
+                  </Button>
+                </Box>
+              )}
+            </ListItem>
+          ))}
       </List>
 
       {/* Add New Discipline Section */}
@@ -182,7 +184,7 @@ export const renderMajors = ({
               <Autocomplete
                 multiple
                 sx={{ width: '60%' }}
-                options={disciplines}
+                options={disciplines.filter(disc => disc.id !== -1)}
                 getOptionLabel={(option) => option.name}
                 value={selectedDisciplines[id] || []}
                 onChange={(_, newValue) => setSelectedDisciplines({ ...selectedDisciplines, [id]: newValue })}

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -441,6 +441,11 @@ export const mockDisciplinesMajors = [
     id: 2,
     name: 'Life Sciences',
     majors: [{ id: 4, name: 'Environmental Science' }, { id: 5, name: 'Chemistry' }, { id: 6, name: 'Biology' }]
+  },
+  {
+    id: -1,
+    name: '',
+    majors: [{ id: 7, name: 'major no discipline' }, { id: 8, name: 'another major' }]
   }
 ]
 export const getMajorsExpectedResponse = [{ id: 1, name: 'Computer Science' }, { id: 2, name: 'Chemistry' }, { id: 3, name: 'Data Science' }]

--- a/frontend/src/utils/adminFetching.js
+++ b/frontend/src/utils/adminFetching.js
@@ -193,7 +193,7 @@ export const handleAddDiscipline = async (newDisciplineName, setNewDisciplineNam
       credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: newDisciplineName })
+      body: JSON.stringify({ newDisciplineName })
     })
 
     if (!response.ok) {

--- a/frontend/src/utils/adminFetching.js
+++ b/frontend/src/utils/adminFetching.js
@@ -16,10 +16,12 @@ import { backendUrl } from '../resources/constants'
 
 // ------------------ MAJORS FUNCTIONS ------------------ //
 export const handleSaveMajor = async (id, editedNameMajor, setEditingIdMajor, selectedDisciplines, majors, setMajors, setError) => {
-  if (selectedDisciplines[id].length === 0) {
-    setError('You must associate this major with one or more disciplines. Please try again.')
+  if (!editedNameMajor.trim()) {
+    setError('Error editing major. Must have a name.')
     return
   }
+
+  const sendTheseDisciplines = selectedDisciplines[id].map(d => d.name)
 
   try {
     const response = await fetch(`${backendUrl}/major?id=${id}`, {
@@ -29,7 +31,7 @@ export const handleSaveMajor = async (id, editedNameMajor, setEditingIdMajor, se
       body: JSON.stringify({
         id,
         name: editedNameMajor,
-        disciplines: selectedDisciplines[id].map(d => d.name)
+        disciplines: sendTheseDisciplines
       })
     })
 
@@ -56,10 +58,6 @@ export const handleSaveMajor = async (id, editedNameMajor, setEditingIdMajor, se
 export const handleAddMajor = async (newMajorName, setNewMajorName, newMajorDisciplines, setDisciplines, prepopulateMajorsWithDisciplines, setLoadingDisciplinesMajors, fetchDisciplines, setError) => {
   if (!newMajorName.trim()) {
     setError('Error adding major. Must have a name.')
-    return
-  }
-  if (newMajorDisciplines.length === 0) {
-    setError('Error adding major. Must be under at least one discipline.')
     return
   }
 
@@ -146,6 +144,11 @@ export const handleDeleteMajor = async (id, setLoadingDisciplinesMajors, majors,
 
 // ------------------ DISCIPLINES FUNCTIONS ------------------ //
 export const handleSaveDiscipline = async (id, editedNameDiscipline, disciplines, setDisciplines, setEditingIdDiscipline, setError) => {
+  if (!editedNameDiscipline.trim()) {
+    setError('Error editing discipline. Must have a name.')
+    return
+  }
+
   try {
     const response = await fetch(`${backendUrl}/discipline?id=${id}`, {
       credentials: 'include',
@@ -190,7 +193,7 @@ export const handleAddDiscipline = async (newDisciplineName, setNewDisciplineNam
       credentials: 'include',
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ newDisciplineName })
+      body: JSON.stringify({ name: newDisciplineName })
     })
 
     if (!response.ok) {
@@ -219,7 +222,7 @@ export const handleAddDiscipline = async (newDisciplineName, setNewDisciplineNam
   }
 }
 
-export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError) => {
+export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines) => {
   setLoadingDisciplinesMajors(true)
 
   const disc = disciplines.find(m => m.id === id)
@@ -242,7 +245,15 @@ export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, di
       throw new Error(response.status)
     }
 
-    setDisciplines(disciplines.filter(d => d.id !== id))
+    // fetch again to show new disciplines and majors connections because the discipline that
+    // was just deleted may have been connected to majors. Now the connections to those majors is removed.
+    const newDisciplinesRes = await fetchDisciplines()
+    if (newDisciplinesRes.length === 0) {
+      throw new Error('505')
+    } else {
+      setDisciplines(newDisciplinesRes)
+      prepopulateMajorsWithDisciplines(newDisciplinesRes)
+    }
     setError(null)
     setDeletingIdDiscipline(null)
     setOpenDeleteDialog(false)
@@ -251,6 +262,8 @@ export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, di
       setError('Bad request.')
     } else if (error.message === '409') {
       setError(`${disc.name} cannot be deleted because it has connections to other projects. Please edit or remove those connections first. Remove connections, then try again.`)
+    } else if (error.message === '505') {
+      setError('Discipline deleted, but there was an error loading updated disciplines and majors data.')
     } else {
       setError(`Unexpected error deleting discipline: ${disc.name}.`)
     }
@@ -261,6 +274,11 @@ export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, di
 
 // ------------------ UMBRELLA TOPICS FUNCTIONS ------------------ //
 export const handleSaveUmbrella = async (id, editedNameUmbrella, umbrellaTopics, setUmbrellaTopics, setEditingIdUmbrella, setError) => {
+  if (!editedNameUmbrella.trim()) {
+    setError('Error editing topic. Must have a name.')
+    return
+  }
+
   try {
     const response = await fetch(`${backendUrl}/umbrella-topic?id=${id}`, {
       credentials: 'include',
@@ -375,6 +393,11 @@ export const handleDeleteUmbrella = async (id, setLoadingUmbrellaTopics, umbrell
 
 // ------------------ RESEARCH PERIODS FUNCTIONS ------------------ //
 export const handleSavePeriod = async (id, editedNamePeriod, setResearchPeriods, researchPeriods, setEditingIdPeriod, setError) => {
+  if (!editedNamePeriod.trim()) {
+    setError('Error editing research period. Must have a name.')
+    return
+  }
+
   try {
     const response = await fetch(`${backendUrl}/research-period?id=${id}`, {
       credentials: 'include',
@@ -489,6 +512,10 @@ export const handleDeletePeriod = async (id, setLoadingResearchPeriods, research
 
 // ------------------ DEPARTMENTS FUNCTIONS ------------------ //
 export const handleSaveDepartment = async (id, editedNameDepartment, departments, setDepartments, setEditingIdDepartment, setError) => {
+  if (!editedNameDepartment.trim()) {
+    setError('Error editing department. Must have a name.')
+    return
+  }
   try {
     const response = await fetch(`${backendUrl}/department?id=${id}`, {
       credentials: 'include',


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** The client requested changes to the admin view for sprint 5. They want to be able to edit, add, and delete disciplines and majors separately. This means that the program logic had to change for how those functions were handled. 
* My solution was to have the `GET /disciplines` endpoint also return a discipline value with id = -1, name '' , and majors being a list of majors without a discipline. This could fit with the existing way that disciplines and majors were rendered on the frontend. 
* Then on the frontend I updated the `handleDeleteDisciplines` function to call the backend again after successful deletion to update the disciplines/majors rendered on the screen, in case any associations are updated.
* Had to update `handleSaveMajor` and `handleAddMajor` to not require a list of disciplines in the request.
* Updated `ManageVariables` and `renderMajors` to correctly render majors and their discipline dropdown lists if no disciplines are selected.

## UI/UX Implementation
Changes requested by client but not made into figma.

## Model Updates
None

### Data Models
None

### Object-Oriented Models
`MajorService` and `MajorRepository` now have methods to get all majors without disciplines.

## End-to-End Testing Instructions
1. login as admin
2. go to manage variables
3. can delete disciplines even if associated with majors already
4. page rerenders and shows accurate info
5. can edit, delete, save majors without disciplines