### PR TITLE
Faculty can edit their own projects

### DIFF
--- a/frontend/src/__tests__/posts/PostDialog.test.js
+++ b/frontend/src/__tests__/posts/PostDialog.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import PostDialog from '../../components/posts/PostDialog'
 import { mockOneActiveProject, mockOneFaculty, mockOneStudent } from '../../resources/mockData'
@@ -122,7 +122,6 @@ describe('PostDialog Component', () => {
       expect(screen.getByText('aescudero@sandiego.edu')).toBeInTheDocument()
       expect(screen.getByText('Computer Science')).toBeInTheDocument()
     })
-
     it('renders the project details correctly (faculty view is projects)', () => {
       renderWithTheme(
         <PostDialog
@@ -148,7 +147,7 @@ describe('PostDialog Component', () => {
         expect(majorRefs.length).toBeGreaterThan(0)
       })
     })
-    it('does NOT edit and delete buttons for project', () => {
+    it('does NOT render edit and delete buttons for project when NOT on their own profile', () => {
       renderWithTheme(
         <PostDialog
           onClose={() => {}}
@@ -157,13 +156,30 @@ describe('PostDialog Component', () => {
           isFaculty
           isAdmin={false}
           postsView={viewProjectsFlag}
+          isOnFacultyProfile={false}
         />
       )
 
       expect(screen.queryByRole('button', { name: /edit project/i })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /delete project/i })).not.toBeInTheDocument()
     })
-    it('does NOT redner edit and delete buttons for student', () => {
+    it('DOES render edit and delete buttons for project when on their own profile', () => {
+      renderWithTheme(
+        <PostDialog
+          onClose={() => {}}
+          post={mockOneActiveProject}
+          isStudent={false}
+          isFaculty
+          isAdmin={false}
+          postsView={viewProjectsFlag}
+          isOnFacultyProfile
+        />
+      )
+
+      expect(screen.getByRole('button', { name: /edit project/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /delete project/i })).toBeInTheDocument()
+    })
+    it('does NOT render edit and delete buttons for viewing student', () => {
       renderWithTheme(
         <PostDialog
           onClose={() => {}}
@@ -177,6 +193,25 @@ describe('PostDialog Component', () => {
 
       expect(screen.queryByRole('button', { name: /edit profile/i })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /delete profile/i })).not.toBeInTheDocument()
+    })
+    it('renders page to edit projects when faculty clicks edit project', async () => {
+      renderWithTheme(
+        <PostDialog
+          onClose={() => {}}
+          post={mockOneActiveProject}
+          isStudent={false}
+          isFaculty
+          isAdmin={false}
+          postsView={viewProjectsFlag}
+          isOnFacultyProfile
+        />
+      )
+
+      const editBtn = screen.getByRole('button', { name: /edit project/i })
+      fireEvent.click(editBtn)
+      await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+      expect(screen.getByText(/edit research opportunity/i)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/__tests__/posts/PostList.test.js
+++ b/frontend/src/__tests__/posts/PostList.test.js
@@ -233,6 +233,62 @@ describe('PostList', () => {
       const emailIcon = screen.queryByTestId('email-icon')
       expect(emailIcon).not.toBeInTheDocument()
     })
+    it('renders all projects (active and inactive) with correct details', () => {
+      const activeAndInactiveProjects = mockThreeActiveProjects.concat(mockTwoInactiveProjects)
+      render(
+        <PostList
+          postings={activeAndInactiveProjects}
+          setSelectedPost={mockSetSelectedPost}
+          isStudent={false}
+          isFaculty
+          isAdmin={false}
+          postsView={viewProjectsFlag}
+          isOnFacultyProfile
+        />
+      )
+
+      expect(screen.getAllByTestId('active-chip').length).toBe(3)
+      expect(screen.getAllByTestId('inactive-chip').length).toBe(2)
+
+      mockThreeActiveProjects.forEach((project) => {
+        expect(screen.getByText(project.name)).toBeInTheDocument()
+        const nameRefs = screen.getAllByText(new RegExp(`${project.faculty.firstName} ${project.faculty.lastName}`, 'i'))
+        expect(nameRefs.length).toBeGreaterThan(0)
+
+        project.researchPeriods.forEach((period) => {
+          const researchReferences = screen.queryAllByText(new RegExp(period))
+          expect(researchReferences.length).toBeGreaterThan(0)
+        })
+
+        project.umbrellaTopics.slice(0, 3).forEach((topic) => {
+          expect(screen.getByText(topic)).toBeInTheDocument()
+        })
+
+        project.majors.forEach((major) => {
+          const majorReferences = screen.getAllByText(major)
+          expect(majorReferences.length).toBeGreaterThan(0) // At least major for "Computer Science" exists in the mock data
+        })
+      })
+      mockTwoInactiveProjects.forEach((project) => {
+        expect(screen.getByText(project.name)).toBeInTheDocument()
+        const nameRefs = screen.getAllByText(new RegExp(`${project.faculty.firstName} ${project.faculty.lastName}`, 'i'))
+        expect(nameRefs.length).toBeGreaterThan(0)
+
+        project.researchPeriods.forEach((period) => {
+          const researchReferences = screen.queryAllByText(new RegExp(period))
+          expect(researchReferences.length).toBeGreaterThan(0)
+        })
+
+        project.umbrellaTopics.slice(0, 3).forEach((topic) => {
+          expect(screen.getByText(topic)).toBeInTheDocument()
+        })
+
+        project.majors.forEach((major) => {
+          const majorReferences = screen.getAllByText(major)
+          expect(majorReferences.length).toBeGreaterThan(0)
+        })
+      })
+    })
   })
 
   describe('when user is admin, viewing students', () => {
@@ -287,6 +343,9 @@ describe('PostList', () => {
           isOnFacultyProfile={false}
         />
       )
+
+      expect(screen.getAllByTestId('active-chip').length).toBe(3)
+      expect(screen.getAllByTestId('inactive-chip').length).toBe(2)
 
       mockThreeActiveProjects.forEach((project) => {
         expect(screen.getByText(project.name)).toBeInTheDocument()

--- a/frontend/src/__tests__/projects/ProjectEdit.test.js
+++ b/frontend/src/__tests__/projects/ProjectEdit.test.js
@@ -110,8 +110,21 @@ describe('ProjectEdit', () => {
     })
   })
 
-  it('populates form fields with fetched project data', async () => {
+  it('populates form fields with fetched project data -- for admin', async () => {
     renderWithTheme(<ProjectEdit />)
+    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+
+    expect(screen.getByDisplayValue(getProjectExpectedResponse.name)).toBeInTheDocument()
+    expect(screen.getByDisplayValue(getProjectExpectedResponse.description)).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /desired qualifications/i })).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: /desired qualifications/i })).toHaveValue(getProjectExpectedResponse.desiredQualifications)
+    expect(screen.getByText(getProjectExpectedResponse.umbrellaTopics[0])).toBeInTheDocument() // indexing the array at 0 because the mock data only has 1 element
+    expect(screen.getByText(getProjectExpectedResponse.researchPeriods[0])).toBeInTheDocument()
+    expect(screen.getByText(getProjectExpectedResponse.majors[0])).toBeInTheDocument()
+  })
+
+  it('populates form fields with fetched project data -- for faculty profile', async () => {
+    renderWithTheme(<ProjectEdit isFaculty myFacultyProjectId={3} />)
     await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
 
     expect(screen.getByDisplayValue(getProjectExpectedResponse.name)).toBeInTheDocument()

--- a/frontend/src/__tests__/projects/ProjectEdit.test.js
+++ b/frontend/src/__tests__/projects/ProjectEdit.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, useNavigate, useParams } from 'react-router-dom'
 import { ThemeProvider, createTheme } from '@mui/material/styles'

--- a/frontend/src/__tests__/projects/ProjectEdit.test.js
+++ b/frontend/src/__tests__/projects/ProjectEdit.test.js
@@ -91,16 +91,6 @@ describe('ProjectEdit', () => {
     fetch.mockImplementation((url) => mockFetch(url, fetchHandlers))
   })
 
-  it('navigates to /posts when back button is clicked', async () => {
-    renderWithTheme(<ProjectEdit />)
-    await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
-
-    const button = screen.getByRole('button', { name: /back/i })
-    fireEvent.click(button)
-
-    expect(mockNavigate).toHaveBeenCalledWith('/posts')
-  })
-
   it('shows a loading spinner initially', () => {
     renderWithTheme(<ProjectEdit />)
     expect(screen.getByRole('progressbar')).toBeInTheDocument()

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -16,6 +16,7 @@ import { Dialog, DialogTitle, DialogContent, Button, Typography, Chip, Box } fro
 import { viewStudentsFlag, viewProjectsFlag, viewFacultyFlag, backendUrl } from '../../resources/constants'
 import { Link, useNavigate } from 'react-router-dom'
 import AreYouSureDialog from '../navigation/AreYouSureDialog'
+import ProjectEdit from '../projects/ProjectEdit'
 
 // Defining the CSS for the Dialog once because it is shared by every view
 const DialogTheme = ({ open, onClose, title, children }) => (
@@ -71,10 +72,12 @@ const DialogTheme = ({ open, onClose, title, children }) => (
   </Dialog>
 )
 
-const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView }) => {
+const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = viewStudentsFlag, isOnFacultyProfile }) => {
   const navigate = useNavigate()
-  const [error, setError] = useState(null)
-  const [openDeleteDialog, setOpenDeleteDialog] = useState(false)
+  const [error, setError] = useState(null) // set to a string value to display error messages
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false) // true if the "are you sure?" dialogue is visible
+  const [showMyOwnProject, setShowMyOwnProject] = useState(false) // true if a faculty member is viewing their own project
+  const [myProjectId, setMyProjectId] = useState(null) // int id of the faculty member's project they are viewing
 
   if (!post) return null
 
@@ -108,7 +111,11 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView })
         if (!response.ok) {
           throw new Error(response.status)
         }
-        window.location.href = '/posts'
+        if (isOnFacultyProfile) {
+          window.location.href = '/view-professor-profile'
+        } else {
+          window.location.href = '/posts'
+        }
       } catch (err) {
         if (err.message === '400') {
           setError('Bad request')
@@ -126,8 +133,23 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView })
     }
   }
 
+  const handleEditMyOwnProjectClick = (id) => {
+    setShowMyOwnProject(true)
+    setMyProjectId(id)
+  }
+
+  if (showMyOwnProject) {
+    return (
+      <>
+        <DialogTheme open={!!post} onClose={() => navigate('/view-professor-profile')} title={post.name}>
+          <ProjectEdit isFaculty myProjectId={myProjectId} />
+        </DialogTheme>
+      </>
+    )
+  }
+
   // rendering projects
-  if (isStudent || ((isFaculty || isAdmin) && postsView === viewProjectsFlag)) {
+  else if (isStudent || ((isFaculty || isAdmin) && postsView === viewProjectsFlag)) {
     const { id, name, description, desiredQualifications, umbrellaTopics = [], researchPeriods = [], isActive, majors = [], faculty = {} } = post
     return (
       <>
@@ -208,15 +230,27 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView })
             }}
           >
 
-            {isAdmin && (
+            {(isAdmin || (isFaculty && isOnFacultyProfile)) && (
               <>
-                <Button
-                  variant='outlined'
-                  color='primary'
-                  onClick={() => { navigate(`/project/${id}`) }}
-                >
-                  Edit Project
-                </Button>
+                {isAdmin && ( // admin are able to edit any project, so they can go to /project/id
+                  <Button
+                    variant='outlined'
+                    color='primary'
+                    onClick={() => { navigate(`/project/${id}`) }}
+                  >
+                    Edit Project
+                  </Button>
+                )}
+
+                {isOnFacultyProfile && ( // faculty are only able to edit their own projects. They cannot go to /project/id to prevent seeing any project id.
+                  <Button
+                    variant='outlined'
+                    color='primary'
+                    onClick={() => handleEditMyOwnProjectClick(id)}
+                  >
+                    Edit Project
+                  </Button>
+                )}
 
                 <Button
                   variant='outlined'

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -146,9 +146,7 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = 
         </DialogTheme>
       </>
     )
-  }
-  // rendering projects
-  else if (isStudent || ((isFaculty || isAdmin) && postsView === viewProjectsFlag)) {
+  } else if (isStudent || ((isFaculty || isAdmin) && postsView === viewProjectsFlag)) { // rendering projects
     const { id, name, description, desiredQualifications, umbrellaTopics = [], researchPeriods = [], isActive, majors = [], faculty = {} } = post
     return (
       <>

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -147,7 +147,6 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = 
       </>
     )
   }
-
   // rendering projects
   else if (isStudent || ((isFaculty || isAdmin) && postsView === viewProjectsFlag)) {
     const { id, name, description, desiredQualifications, umbrellaTopics = [], researchPeriods = [], isActive, majors = [], faculty = {} } = post
@@ -274,7 +273,6 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = 
         />
       </>
     )
-
   // rendering students
   } else if ((isFaculty || isAdmin) && postsView === viewStudentsFlag) {
     const { id, firstName, lastName, isActive, email, classStatus, graduationYear, majors = [], researchFieldInterests = [], researchPeriodsInterest = [], interestReason, hasPriorExperience } = post
@@ -386,7 +384,6 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = 
         />
       </>
     )
-
   // rendering faculty
   } else if (isAdmin && postsView === viewFacultyFlag) {
     const { id, firstName, lastName, email, department, projects } = post

--- a/frontend/src/components/posts/PostList.js
+++ b/frontend/src/components/posts/PostList.js
@@ -67,7 +67,7 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, p
                     <EmailIcon data-testid='email-icon' />
                   )}
                 </IconButton>
-                {!post.isActive && isAdmin && (
+                {!post.isActive && (isAdmin || isOnFacultyProfile) && (
                   <Chip
                     label='Inactive'
                     sx={{
@@ -76,9 +76,10 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, p
                       top: 8,
                       right: 20
                     }}
+                    data-testid='inactive-chip'
                   />
                 )}
-                {post.isActive && isAdmin && (
+                {post.isActive && (isAdmin || isOnFacultyProfile) && (
                   <Chip
                     label='Active'
                     sx={{
@@ -87,6 +88,7 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, p
                       top: 8,
                       right: 20
                     }}
+                    data-testid='active-chip'
                   />
                 )}
 

--- a/frontend/src/components/profiles/FacultyProfileView.js
+++ b/frontend/src/components/profiles/FacultyProfileView.js
@@ -142,6 +142,7 @@ const FacultyProfileView = () => {
               isFaculty
               isAdmin={false}
               postsView={viewProjectsFlag}
+              isOnFacultyProfile
             />
           </>
           )}

--- a/frontend/src/components/projects/ProjectEdit.js
+++ b/frontend/src/components/projects/ProjectEdit.js
@@ -52,10 +52,10 @@ const renderMultiSelectChips = (selected) => (
   </Box>
 )
 
-const ProjectEdit = (isFaculty, myFacultyProjectId) => {
+const ProjectEdit = ({ isFaculty = false, myFacultyProjectId = null }) => {
   // If admin is editing any project, id comes from URL params. If faculty is editing their own project, id comes from prop
-  const { id: paramId } = useParams()
-  const projectId = isFaculty ? myFacultyProjectId : paramId
+  const { id } = useParams()
+  const projectId = isFaculty ? myFacultyProjectId : id
 
   const [formData, setFormData] = useState({
     id: projectId,
@@ -142,7 +142,7 @@ const ProjectEdit = (isFaculty, myFacultyProjectId) => {
         if (!response.ok) throw new Error(response.status)
         const data = await response.json()
 
-        if (data.id !== parseInt(projectId)) throw new Error('ID in URL is not the same as returned.')
+        if (data.id !== parseInt(projectId)) throw new Error(`ID in request ${parseInt(projectId)} is not the same as returned ${data.id}.`)
 
         const selectedMajors = getSelectedMajors(disciplinesRes, data.majors)
         setSelectedMajors(selectedMajors)
@@ -158,6 +158,7 @@ const ProjectEdit = (isFaculty, myFacultyProjectId) => {
           isActive: data.isActive
         })
       } catch (error) {
+        // setError(error.message)
         setError('An unexpected error occurred while getting project details. Please try again.')
       } finally {
         setLoading(false)

--- a/frontend/src/components/projects/ProjectEdit.js
+++ b/frontend/src/components/projects/ProjectEdit.js
@@ -33,7 +33,7 @@ import {
 import SaveIcon from '@mui/icons-material/Save'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import fetchResearchPeriods from '../../utils/fetchResearchPeriods'
 import fetchUmbrellaTopics from '../../utils/fetchUmbrellaTopics'
 import fetchDisciplines from '../../utils/fetchDisciplines'
@@ -52,11 +52,13 @@ const renderMultiSelectChips = (selected) => (
   </Box>
 )
 
-const ProjectEdit = () => {
-  const navigate = useNavigate()
-  const { id } = useParams()
+const ProjectEdit = (isFaculty, myFacultyProjectId) => {
+  // If admin is editing any project, id comes from URL params. If faculty is editing their own project, id comes from prop
+  const { id: paramId } = useParams()
+  const projectId = isFaculty ? myFacultyProjectId : paramId
+
   const [formData, setFormData] = useState({
-    id,
+    id: projectId,
     title: '',
     description: '',
     disciplines: [],
@@ -130,7 +132,7 @@ const ProjectEdit = () => {
         setUmbrellaTopics(umbrellaTopicsRes)
         setDisciplineOptions(disciplinesRes)
 
-        const response = await fetch(`${backendUrl}/project?id=${parseInt(id)}`, {
+        const response = await fetch(`${backendUrl}/project?id=${parseInt(projectId)}`, {
           method: 'GET',
           credentials: 'include',
           headers: {
@@ -140,13 +142,13 @@ const ProjectEdit = () => {
         if (!response.ok) throw new Error(response.status)
         const data = await response.json()
 
-        if (data.id !== parseInt(id)) throw new Error('ID in URL is not the same as returned.')
+        if (data.id !== parseInt(projectId)) throw new Error('ID in URL is not the same as returned.')
 
         const selectedMajors = getSelectedMajors(disciplinesRes, data.majors)
         setSelectedMajors(selectedMajors)
 
         setFormData({
-          id: parseInt(id),
+          id: parseInt(projectId),
           title: data.name,
           description: data.description,
           disciplines: [],
@@ -162,7 +164,7 @@ const ProjectEdit = () => {
       }
     }
     fetchData()
-  }, [id])
+  }, [projectId])
 
   // Handle text input changes
   const handleChange = (e) => {
@@ -269,9 +271,6 @@ const ProjectEdit = () => {
           borderRadius: 2
         }}
       >
-        <Button variant='outlined' onClick={() => { navigate('/posts') }} sx={{ mb: 2 }}>
-          Back
-        </Button>
         {/* Header */}
         <Box
           sx={{


### PR DESCRIPTION
# Overview

**Type of Change:**  New Feature

**Summary:** Updated the frontend so that faculty can now edit their own projects. Reused `ProjectEdit.js` that allows admins to also edit projects, however the component is rendered from the `PostDialog` component rather than from a route. While admins edit from /project/id, faculty must be able to edit from the same page as their profile, /view-professor-profile, to prevent faculty from being able to go to any /project/id and edit any project. Faculty. Props like showingMyFacultyProject, isFaculty, etc make it so faculty can’t edit any project; only their own.

## UI/UX Implementation
https://www.figma.com/design/DhiOgiITPexVdSPS3W333C/Sprint-5?node-id=0-1&p=f&t=U2QYIt5bKObo3a7t-0

## Model Updates
New props and small logic changes to render proper data for faculty in:
PostDialog
PostList
ProjectEdit

### Data Models
None

### Object-Oriented Models
None

## End-to-End Testing Instructions
1. login as faculty
2. go to view my profile
3. click on a project
4. click edit project or delete project