### PR TITLE
Feature/retrieve email templates endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/enums/EmailNotificationType.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/enums/EmailNotificationType.java
@@ -1,6 +1,6 @@
 package COMP_49X_our_search.backend.database.enums;
 
 public enum EmailNotificationType {
-    STUDENT,
+    STUDENTS,
     FACULTY
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -77,6 +77,8 @@ import COMP_49X_our_search.backend.gateway.dto.UmbrellaTopicDTO;
 import COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter;
 import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoFacultyToFacultyDto;
 import static COMP_49X_our_search.backend.gateway.util.ProjectHierarchyConverter.protoStudentToStudentDto;
+import static COMP_49X_our_search.backend.util.ClassStatusConverter.toClassStatus;
+
 import COMP_49X_our_search.backend.security.LogoutService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -463,7 +465,7 @@ public class GatewayController {
 
   @PutMapping("/umbrella-topic")
   public ResponseEntity<UmbrellaTopicDTO> editUmbrellaTopic(
-          @RequestBody UmbrellaTopicDTO topicToUpdate) {
+      @RequestBody UmbrellaTopicDTO topicToUpdate) {
     try {
       UmbrellaTopic existing = umbrellaTopicService.getUmbrellaTopicById(topicToUpdate.getId());
       existing.setName(topicToUpdate.getName());
@@ -475,12 +477,9 @@ public class GatewayController {
 
     } catch (Exception e) {
       e.printStackTrace();
-      return ResponseEntity
-              .status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .build();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
-
 
   @PutMapping("/api/facultyProfiles/current")
   public ResponseEntity<FacultyDTO> editFacultyProfile(
@@ -952,8 +951,7 @@ public class GatewayController {
               project.getResearchPeriods().stream().map(ResearchPeriod::getName).toList(),
               project.getIsActive(),
               project.getMajors().stream().map(Major::getName).toList(),
-              null
-          );
+              null);
       return ResponseEntity.ok(responseProjectDTO);
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
@@ -973,13 +971,13 @@ public class GatewayController {
 
       Discipline savedDiscipline = disciplineService.saveDiscipline(discipline);
 
-      DisciplineDTO updatedDto = new DisciplineDTO(
+      DisciplineDTO updatedDto =
+          new DisciplineDTO(
               savedDiscipline.getId(),
               savedDiscipline.getName(),
               majorService.getMajorsByDisciplineId(savedDiscipline.getId()).stream()
-                      .map(major -> new MajorDTO(major.getId(), major.getName()))
-                      .toList()
-      );
+                  .map(major -> new MajorDTO(major.getId(), major.getName()))
+                  .toList());
 
       return ResponseEntity.ok(updatedDto);
     } catch (Exception e) {
@@ -987,7 +985,7 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
-      
+
   @DeleteMapping("/umbrella-topic")
   public ResponseEntity<Void> deleteUmbrellaTopic(@RequestBody DeleteRequestDTO requestBody) {
     try {
@@ -1005,39 +1003,39 @@ public class GatewayController {
   @GetMapping("/faculty")
   public ResponseEntity<FacultyDTO> getFaculty(@RequestParam("id") int facultyId) {
     try {
-        Faculty dbFaculty = facultyService.getFacultyById(facultyId);
+      Faculty dbFaculty = facultyService.getFacultyById(facultyId);
 
-        List<Project> projects = projectService.getProjectsByFacultyId(dbFaculty.getId());
-        List<ProjectDTO> projectDTOs = projects.stream()
-            .map(project -> new ProjectDTO(
-                project.getId(),
-                project.getName(),
-                project.getDescription(),
-                project.getDesiredQualifications(),
-                project.getUmbrellaTopics().stream().map(ut -> ut.getName()).toList(),
-                project.getResearchPeriods().stream().map(rp -> rp.getName()).toList(),
-                project.getIsActive(),
-                project.getMajors().stream().map(m -> m.getName()).toList(),
-                null
+      List<Project> projects = projectService.getProjectsByFacultyId(dbFaculty.getId());
+      List<ProjectDTO> projectDTOs =
+          projects.stream()
+              .map(
+                  project ->
+                      new ProjectDTO(
+                          project.getId(),
+                          project.getName(),
+                          project.getDescription(),
+                          project.getDesiredQualifications(),
+                          project.getUmbrellaTopics().stream().map(ut -> ut.getName()).toList(),
+                          project.getResearchPeriods().stream().map(rp -> rp.getName()).toList(),
+                          project.getIsActive(),
+                          project.getMajors().stream().map(m -> m.getName()).toList(),
+                          null))
+              .toList();
 
-            ))
-            .toList();
+      List<String> departmentNames =
+          dbFaculty.getDepartments().stream().map(dept -> dept.getName()).toList();
 
-        List<String> departmentNames = dbFaculty.getDepartments().stream()
-            .map(dept -> dept.getName())
-            .toList();
+      FacultyDTO facultyDTO = new FacultyDTO();
+      facultyDTO.setId(dbFaculty.getId());
+      facultyDTO.setFirstName(dbFaculty.getFirstName());
+      facultyDTO.setLastName(dbFaculty.getLastName());
+      facultyDTO.setEmail(dbFaculty.getEmail());
+      facultyDTO.setDepartment(departmentNames);
+      facultyDTO.setProjects(projectDTOs);
 
-        FacultyDTO facultyDTO = new FacultyDTO();
-        facultyDTO.setId(dbFaculty.getId());
-        facultyDTO.setFirstName(dbFaculty.getFirstName());
-        facultyDTO.setLastName(dbFaculty.getLastName());
-        facultyDTO.setEmail(dbFaculty.getEmail());
-        facultyDTO.setDepartment(departmentNames);
-        facultyDTO.setProjects(projectDTOs);
-
-        return ResponseEntity.ok(facultyDTO);
+      return ResponseEntity.ok(facultyDTO);
     } catch (Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
 
@@ -1052,10 +1050,12 @@ public class GatewayController {
 
       Discipline savedDiscipline = disciplineService.saveDiscipline(discipline);
 
-      List<MajorDTO> majorDTOs = majorService.getMajorsByDisciplineId(savedDiscipline.getId()).stream()
+      List<MajorDTO> majorDTOs =
+          majorService.getMajorsByDisciplineId(savedDiscipline.getId()).stream()
               .map(major -> new MajorDTO(major.getId(), major.getName()))
               .toList();
-      DisciplineDTO responseDTO = new DisciplineDTO(savedDiscipline.getId(), savedDiscipline.getName(), majorDTOs);
+      DisciplineDTO responseDTO =
+          new DisciplineDTO(savedDiscipline.getId(), savedDiscipline.getName(), majorDTOs);
 
       return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
     } catch (Exception e) {
@@ -1067,34 +1067,37 @@ public class GatewayController {
   @GetMapping("/student")
   public ResponseEntity<StudentDTO> getStudent(@RequestParam("id") int studentId) {
     try {
-        Student dbStudent = studentService.getStudentById(studentId);
-        
-        // Manually build a StudentDTO from the Student entity.
-        StudentDTO studentDTO = new StudentDTO();
-        studentDTO.setId(dbStudent.getId());
-        studentDTO.setFirstName(dbStudent.getFirstName());
-        studentDTO.setLastName(dbStudent.getLastName());
-        studentDTO.setEmail(dbStudent.getEmail());
-        studentDTO.setClassStatus(undergradYearToClassStatus(dbStudent.getUndergradYear()));
-        studentDTO.setGraduationYear(dbStudent.getGraduationYear());
-        studentDTO.setMajors(dbStudent.getMajors().stream().map(Major::getName).toList());
-        studentDTO.setResearchFieldInterests(dbStudent.getResearchFieldInterests().stream().map(Major::getName).toList());
-        studentDTO.setResearchPeriodsInterest(dbStudent.getResearchPeriods().stream().map(ResearchPeriod::getName).toList());
-        studentDTO.setInterestReason(dbStudent.getInterestReason());
-        studentDTO.setHasPriorExperience(dbStudent.getHasPriorExperience());
-        studentDTO.setIsActive(dbStudent.getIsActive());
-        
-        return ResponseEntity.ok(studentDTO);
+      Student dbStudent = studentService.getStudentById(studentId);
+
+      // Manually build a StudentDTO from the Student entity.
+      StudentDTO studentDTO = new StudentDTO();
+      studentDTO.setId(dbStudent.getId());
+      studentDTO.setFirstName(dbStudent.getFirstName());
+      studentDTO.setLastName(dbStudent.getLastName());
+      studentDTO.setEmail(dbStudent.getEmail());
+      studentDTO.setClassStatus(toClassStatus(dbStudent.getUndergradYear()));
+      studentDTO.setGraduationYear(dbStudent.getGraduationYear());
+      studentDTO.setMajors(dbStudent.getMajors().stream().map(Major::getName).toList());
+      studentDTO.setResearchFieldInterests(
+          dbStudent.getResearchFieldInterests().stream().map(Major::getName).toList());
+      studentDTO.setResearchPeriodsInterest(
+          dbStudent.getResearchPeriods().stream().map(ResearchPeriod::getName).toList());
+      studentDTO.setInterestReason(dbStudent.getInterestReason());
+      studentDTO.setHasPriorExperience(dbStudent.getHasPriorExperience());
+      studentDTO.setIsActive(dbStudent.getIsActive());
+
+      return ResponseEntity.ok(studentDTO);
     } catch (Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
 
   @PutMapping("/research-period")
-  public ResponseEntity<ResearchPeriodDTO> editResearchPeriod(@RequestBody ResearchPeriodDTO requestBody) {
+  public ResponseEntity<ResearchPeriodDTO> editResearchPeriod(
+      @RequestBody ResearchPeriodDTO requestBody) {
     try {
-      ResearchPeriod researchPeriod = researchPeriodService.getResearchPeriodById(requestBody.getId());
-
+      ResearchPeriod researchPeriod =
+          researchPeriodService.getResearchPeriodById(requestBody.getId());
 
       if (requestBody.getName().isEmpty()) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -1104,10 +1107,8 @@ public class GatewayController {
 
       ResearchPeriod savedResearchPeriod = researchPeriodService.saveResearchPeriod(researchPeriod);
 
-      ResearchPeriodDTO updatedDto = new ResearchPeriodDTO(
-        savedResearchPeriod.getId(),
-        savedResearchPeriod.getName()
-      );
+      ResearchPeriodDTO updatedDto =
+          new ResearchPeriodDTO(savedResearchPeriod.getId(), savedResearchPeriod.getName());
 
       return ResponseEntity.ok(updatedDto);
     } catch (Exception e) {
@@ -1124,15 +1125,15 @@ public class GatewayController {
       Department dept = departmentService.getDepartmentById(requestBody.getId());
       dept.setName(requestBody.getName());
       Department savedDept = departmentService.saveDepartment(dept);
-      
-      DepartmentDTO responseDto = new DepartmentDTO(savedDept.getId(), savedDept.getName(), null, null);
+
+      DepartmentDTO responseDto =
+          new DepartmentDTO(savedDept.getId(), savedDept.getName(), null, null);
       return ResponseEntity.ok(responseDto);
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
 
-  
   @DeleteMapping("/major")
   public ResponseEntity<Void> deleteMajor(@RequestBody DeleteRequestDTO requestBody) {
     try {
@@ -1156,9 +1157,10 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
   }
-  
+
   @PostMapping("/umbrella-topic")
-  public ResponseEntity<UmbrellaTopicDTO> createUmbrellaTopic(@RequestBody UmbrellaTopicDTO requestBody) {
+  public ResponseEntity<UmbrellaTopicDTO> createUmbrellaTopic(
+      @RequestBody UmbrellaTopicDTO requestBody) {
     try {
       if (requestBody.getName() == null || requestBody.getName().trim().isEmpty()) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -1175,21 +1177,21 @@ public class GatewayController {
   }
 
   @PostMapping("/research-period")
-  public ResponseEntity<ResearchPeriodDTO> createResearchPeriod(@RequestBody ResearchPeriodDTO requestBody) {
+  public ResponseEntity<ResearchPeriodDTO> createResearchPeriod(
+      @RequestBody ResearchPeriodDTO requestBody) {
     try {
       if (requestBody.getName() == null || requestBody.getName().isEmpty()) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
       }
-      
+
       ResearchPeriod newPeriod = new ResearchPeriod();
       newPeriod.setName(requestBody.getName());
-      
-      
+
       ResearchPeriod savedPeriod = researchPeriodService.saveResearchPeriod(newPeriod);
-      
-      
-      ResearchPeriodDTO responseDto = new ResearchPeriodDTO(savedPeriod.getId(), savedPeriod.getName());
-      
+
+      ResearchPeriodDTO responseDto =
+          new ResearchPeriodDTO(savedPeriod.getId(), savedPeriod.getName());
+
       return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
@@ -1204,10 +1206,11 @@ public class GatewayController {
       }
       Department newDept = new Department();
       newDept.setName(requestBody.getName());
-      
+
       Department savedDept = departmentService.saveDepartment(newDept);
-      
-      DepartmentDTO responseDto = new DepartmentDTO(savedDept.getId(), savedDept.getName(), null, null);
+
+      DepartmentDTO responseDto =
+          new DepartmentDTO(savedDept.getId(), savedDept.getName(), null, null);
       return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
@@ -1215,32 +1218,46 @@ public class GatewayController {
   }
 
   @PutMapping("/email-templates")
-  public ResponseEntity<List<EmailNotificationDTO>> editEmailNotifications(@RequestBody List<EmailNotificationDTO> requestBody) {
+  public ResponseEntity<List<EmailNotificationDTO>> editEmailNotifications(
+      @RequestBody List<EmailNotificationDTO> requestBody) {
     try {
       for (EmailNotificationDTO dto : requestBody) {
-        if (dto.getType() == null || dto.getType().trim().isEmpty() ||
-                dto.getSubject() == null || dto.getSubject().trim().isEmpty() ||
-                dto.getBody() == null || dto.getBody().trim().isEmpty()) {
+        if (dto.getType() == null
+            || dto.getType().trim().isEmpty()
+            || dto.getSubject() == null
+            || dto.getSubject().trim().isEmpty()
+            || dto.getBody() == null
+            || dto.getBody().trim().isEmpty()) {
           return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
       }
-      List<EmailNotification> updatedNotifications = emailNotificationService.getAllEmailNotifications()
-              .stream()
-              .map(notification ->
+      List<EmailNotification> updatedNotifications =
+          emailNotificationService.getAllEmailNotifications().stream()
+              .map(
+                  notification ->
                       requestBody.stream()
-                              .filter(dto -> notification.getEmailNotificationType().name().equalsIgnoreCase(dto.getType()))
-                              .findFirst()
-                              .map(dto -> {
+                          .filter(
+                              dto ->
+                                  notification
+                                      .getEmailNotificationType()
+                                      .name()
+                                      .equalsIgnoreCase(dto.getType()))
+                          .findFirst()
+                          .map(
+                              dto -> {
                                 notification.setSubject(dto.getSubject());
                                 notification.setBody(dto.getBody());
                                 return emailNotificationService.saveEmailNotification(notification);
                               })
-                              .orElse(notification)
-              )
+                          .orElse(notification))
               .toList();
 
-      List<EmailNotificationDTO> updatedDtos = updatedNotifications.stream()
-              .map(n -> new EmailNotificationDTO(n.getEmailNotificationType().name(), n.getSubject(), n.getBody()))
+      List<EmailNotificationDTO> updatedDtos =
+          updatedNotifications.stream()
+              .map(
+                  n ->
+                      new EmailNotificationDTO(
+                          n.getEmailNotificationType().name(), n.getSubject(), n.getBody()))
               .toList();
 
       return ResponseEntity.ok(updatedDtos);
@@ -1250,15 +1267,21 @@ public class GatewayController {
     }
   }
 
-  // Helper method
-  private String undergradYearToClassStatus(int status) {
-    switch (status) {
-      case 1: return "Freshman";
-      case 2: return "Sophomore";
-      case 3: return "Junior";
-      case 4: return "Senior";
-      case 5: return "Graduate";
-      default: throw new IllegalArgumentException("Invalid class status: " + status);
-    }
+  @GetMapping("/email-templates")
+  public ResponseEntity<List<EmailNotificationDTO>> getEmailNotifications() {
+    List<EmailNotification> emailNotifications =
+        emailNotificationService.getAllEmailNotifications();
+
+    List<EmailNotificationDTO> emailNotificationDTOS =
+        emailNotifications.stream()
+            .map(
+                notification ->
+                    new EmailNotificationDTO(
+                        notification.getEmailNotificationType().name(),
+                        notification.getSubject(),
+                        notification.getBody()))
+            .toList();
+
+    return ResponseEntity.ok(emailNotificationDTOS);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/StudentProfileCreator.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/StudentProfileCreator.java
@@ -8,6 +8,8 @@
  */
 package COMP_49X_our_search.backend.profile;
 
+import static COMP_49X_our_search.backend.util.ClassStatusConverter.toUndergradYear;
+
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.entities.ResearchPeriod;
 import COMP_49X_our_search.backend.database.entities.Student;
@@ -100,7 +102,7 @@ public class StudentProfileCreator implements ProfileCreator {
       dbStudent.setHasPriorExperience(studentProfile.getHasPriorExperience());
       dbStudent.setIsActive(true);
       dbStudent.setUndergradYear(
-          convertClassStatusToUndergradYear(studentProfile.getClassStatus()));
+          toUndergradYear(studentProfile.getClassStatus()));
 
       Student createdStudent = studentService.saveStudent(dbStudent);
 
@@ -116,23 +118,6 @@ public class StudentProfileCreator implements ProfileCreator {
           .setSuccess(false)
           .setErrorMessage(e.getMessage())
           .build();
-    }
-  }
-
-  private int convertClassStatusToUndergradYear(String classStatus) {
-    switch (classStatus) {
-      case "Freshman":
-        return 1;
-      case "Sophomore":
-        return 2;
-      case "Junior":
-        return 3;
-      case "Senior":
-        return 4;
-      case "Fifth Year":
-        return 5;
-      default:
-        throw new IllegalArgumentException("Class status not supported: " + classStatus);
     }
   }
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/profile/StudentProfileEditor.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/profile/StudentProfileEditor.java
@@ -8,6 +8,8 @@
  */
 package COMP_49X_our_search.backend.profile;
 
+import static COMP_49X_our_search.backend.util.ClassStatusConverter.toUndergradYear;
+
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.entities.ResearchPeriod;
 import COMP_49X_our_search.backend.database.entities.Student;
@@ -63,7 +65,7 @@ public class StudentProfileEditor implements ProfileEditor {
       existingStudent.setInterestReason(updatedProfile.getInterestReason());
       existingStudent.setHasPriorExperience(updatedProfile.getHasPriorExperience());
       existingStudent.setUndergradYear(
-          convertClassStatusToUndergradYear(updatedProfile.getClassStatus()));
+          toUndergradYear(updatedProfile.getClassStatus()));
       existingStudent.setIsActive(updatedProfile.getIsActive());
 
       Set<Major> updatedMajors =
@@ -115,23 +117,6 @@ public class StudentProfileEditor implements ProfileEditor {
           .setSuccess(false)
           .setErrorMessage(e.getMessage())
           .build();
-    }
-  }
-
-  private int convertClassStatusToUndergradYear(String classStatus) {
-    switch (classStatus) {
-      case "Freshman":
-        return 1;
-      case "Sophomore":
-        return 2;
-      case "Junior":
-        return 3;
-      case "Senior":
-        return 4;
-      case "Graduate":
-        return 5;
-      default:
-        throw new IllegalArgumentException("Class status not supported: " + classStatus);
     }
   }
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/util/ClassStatusConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/util/ClassStatusConverter.java
@@ -1,0 +1,38 @@
+package COMP_49X_our_search.backend.util;
+
+public class ClassStatusConverter {
+
+  public static int toUndergradYear(String classStatus) {
+    switch (classStatus) {
+      case "Freshman":
+        return 1;
+      case "Sophomore":
+        return 2;
+      case "Junior":
+        return 3;
+      case "Senior":
+        return 4;
+      case "Graduate":
+        return 5;
+      default:
+        throw new IllegalArgumentException("Class status not supported: " + classStatus);
+    }
+  }
+
+  public static String toClassStatus(int undergradYear) {
+    switch (undergradYear) {
+      case 1:
+        return "Freshman";
+      case 2:
+        return "Sophomore";
+      case 3:
+        return "Junior";
+      case 4:
+        return "Senior";
+      case 5:
+        return "Graduate";
+      default:
+        throw new IllegalArgumentException("Undergrad year not supported: " + undergradYear);
+    }
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/util/ProtoConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/util/ProtoConverter.java
@@ -11,6 +11,8 @@
  */
 package COMP_49X_our_search.backend.util;
 
+import static COMP_49X_our_search.backend.util.ClassStatusConverter.toClassStatus;
+
 import COMP_49X_our_search.backend.database.entities.Department;
 import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Faculty;
@@ -69,7 +71,7 @@ public class ProtoConverter {
         .setFirstName(student.getFirstName())
         .setLastName(student.getLastName())
         .setEmail(student.getEmail())
-        .setClassStatus(getClassStatus(student.getUndergradYear()))
+        .setClassStatus(toClassStatus(student.getUndergradYear()))
         .setGraduationYear(student.getGraduationYear())
         .addAllMajors(student.getMajors().stream().map(Major::getName).sorted().toList())
         .addAllResearchFieldInterests(
@@ -90,22 +92,5 @@ public class ProtoConverter {
         .addAllDepartments(faculty.getDepartments().stream().map(Department::getName).sorted().toList())
         .setFacultyId(faculty.getId())
         .build();
-  }
-
-  private static String getClassStatus(Integer undergradYear) {
-    switch (undergradYear) {
-      case 1:
-        return "Freshman";
-      case 2:
-        return "Sophomore";
-      case 3:
-        return "Junior";
-      case 4:
-        return "Senior";
-      case 5:
-        return "Fifth Year";
-      default:
-        return "Unknown";
-    }
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/EmailNotificationServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/EmailNotificationServiceTest.java
@@ -31,9 +31,9 @@ public class EmailNotificationServiceTest {
         EmailNotification notification = new EmailNotification();
         notification.setBody("Test body");
         notification.setSubject("Test subject");
-        notification.setEmailNotificationType(EmailNotificationType.STUDENT);
+        notification.setEmailNotificationType(EmailNotificationType.STUDENTS);
 
-        EmailNotification savedNotification = new EmailNotification(1, "Test body", "Test subject", EmailNotificationType.STUDENT);
+        EmailNotification savedNotification = new EmailNotification(1, "Test body", "Test subject", EmailNotificationType.STUDENTS);
 
         when(emailNotificationRepository.save(notification)).thenReturn(savedNotification);
 
@@ -43,14 +43,14 @@ public class EmailNotificationServiceTest {
         assertEquals(1, result.getId());
         assertEquals("Test body", result.getBody());
         assertEquals("Test subject", result.getSubject());
-        assertEquals(EmailNotificationType.STUDENT, result.getEmailNotificationType());
+        assertEquals(EmailNotificationType.STUDENTS, result.getEmailNotificationType());
 
         verify(emailNotificationRepository, times(1)).save(notification);
     }
 
     @Test
     void testGetAllEmailNotifications() {
-        EmailNotification notification1 = new EmailNotification(1, "Body1", "Subject1", EmailNotificationType.STUDENT);
+        EmailNotification notification1 = new EmailNotification(1, "Body1", "Subject1", EmailNotificationType.STUDENTS);
         EmailNotification notification2 = new EmailNotification(2, "Body2", "Subject2", EmailNotificationType.FACULTY);
         List<EmailNotification> notifications = Arrays.asList(notification1, notification2);
 

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1721,7 +1721,7 @@ void editDepartment_returnsExpectedResult() throws Exception {
     studentNotification.setId(1);
     studentNotification.setSubject("Old Student Subject");
     studentNotification.setBody("Old Student Body");
-    studentNotification.setEmailNotificationType(EmailNotificationType.STUDENT);
+    studentNotification.setEmailNotificationType(EmailNotificationType.STUDENTS);
 
     EmailNotification facultyNotification = new EmailNotification();
     facultyNotification.setId(2);
@@ -1735,7 +1735,7 @@ void editDepartment_returnsExpectedResult() throws Exception {
             .thenAnswer(invocation -> invocation.getArgument(0));
 
     List<EmailNotificationDTO> requestList = List.of(
-            new EmailNotificationDTO("STUDENT", "New Student Subject", "New Student Body"),
+            new EmailNotificationDTO("STUDENTS", "New Student Subject", "New Student Body"),
             new EmailNotificationDTO("FACULTY", "New Faculty Subject", "New Faculty Body")
     );
 
@@ -1745,8 +1745,8 @@ void editDepartment_returnsExpectedResult() throws Exception {
                             .content(objectMapper.writeValueAsString(requestList)))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.length()").value(2))
-            .andExpect(jsonPath("$[?(@.type=='STUDENT')].subject").value(hasItem("New Student Subject")))
-            .andExpect(jsonPath("$[?(@.type=='STUDENT')].body").value(hasItem("New Student Body")))
+            .andExpect(jsonPath("$[?(@.type=='STUDENTS')].subject").value(hasItem("New Student Subject")))
+            .andExpect(jsonPath("$[?(@.type=='STUDENTS')].body").value(hasItem("New Student Body")))
             .andExpect(jsonPath("$[?(@.type=='FACULTY')].subject").value(hasItem("New Faculty Subject")))
             .andExpect(jsonPath("$[?(@.type=='FACULTY')].body").value(hasItem("New Faculty Body")));
 
@@ -1804,4 +1804,33 @@ void createResearchPeriod_returnsExpectedResult() throws Exception {
         .andExpect(jsonPath("$.id").value(deptId))
         .andExpect(jsonPath("$.name").value(deptName));
     }
+
+  @Test
+  @WithMockUser
+  void getEmailNotifications_returnsExpectedResult() throws Exception {
+    EmailNotification notification1 = new EmailNotification();
+    notification1.setId(1);
+    notification1.setSubject("Welcome Student");
+    notification1.setBody("Hello, welcome to the research portal!");
+    notification1.setEmailNotificationType(EmailNotificationType.STUDENTS);
+
+    EmailNotification notification2 = new EmailNotification();
+    notification2.setId(2);
+    notification2.setSubject("Faculty Match");
+    notification2.setBody("A student is interested in your research!");
+    notification2.setEmailNotificationType(EmailNotificationType.FACULTY);
+
+    when(emailNotificationService.getAllEmailNotifications())
+        .thenReturn(List.of(notification1, notification2));
+
+    mockMvc.perform(get("/email-templates"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[?(@.type=='STUDENTS')].subject").value(hasItem("Welcome Student")))
+        .andExpect(jsonPath("$[?(@.type=='STUDENTS')].body").value(hasItem("Hello, welcome to the research portal!")))
+        .andExpect(jsonPath("$[?(@.type=='FACULTY')].subject").value(hasItem("Faculty Match")))
+        .andExpect(jsonPath("$[?(@.type=='FACULTY')].body").value(hasItem("A student is interested in your research!")));
+
+    verify(emailNotificationService, times(1)).getAllEmailNotifications();
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/util/ClassStatusConverterTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/util/ClassStatusConverterTest.java
@@ -1,0 +1,47 @@
+package COMP_49X_our_search.backend.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ClassStatusConverterTest {
+
+  @Test
+  public void testToUndergradYear_validYear_returnsExpectedResponse() {
+    assertEquals(1, ClassStatusConverter.toUndergradYear("Freshman"));
+    assertEquals(2, ClassStatusConverter.toUndergradYear("Sophomore"));
+    assertEquals(3, ClassStatusConverter.toUndergradYear("Junior"));
+    assertEquals(4, ClassStatusConverter.toUndergradYear("Senior"));
+    assertEquals(5, ClassStatusConverter.toUndergradYear("Graduate"));
+  }
+
+  @Test
+  public void testToUndergradYear_invalidYear_throwsException() {
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              ClassStatusConverter.toUndergradYear("PhD");
+            });
+    assertEquals("Class status not supported: PhD", exception.getMessage());
+  }
+
+  @Test
+  public void testToClassStatus_validStatus_returnsExpectedResponse() {
+    assertEquals("Freshman", ClassStatusConverter.toClassStatus(1));
+    assertEquals("Sophomore", ClassStatusConverter.toClassStatus(2));
+    assertEquals("Junior", ClassStatusConverter.toClassStatus(3));
+    assertEquals("Senior", ClassStatusConverter.toClassStatus(4));
+    assertEquals("Graduate", ClassStatusConverter.toClassStatus(5));
+  }
+
+  @Test
+  public void testToClassStatus_invalidStatus_throwsException() {
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              ClassStatusConverter.toClassStatus(6);
+            });
+    assertEquals("Undergrad year not supported: 6", exception.getMessage());
+  }
+}


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature / Refactoring

**Summary:** Add `GET` mapping at `/email-templates` endpoint to retrieve all email templates.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

- Changed `EmailNotificationType` enum possible value from `STUDENT` to `STUDENTS`.

### Object-Oriented Models

- Moved undergrad year <-> class status conversion functions to an util file.

## End-to-End Testing Instructions

1. Make sure the frontend app, the backend app, and the mysql database are running and that there is valid email notification data in the database.
2. Send `GET` request to endpoint `http:localhost:8080/email-templates` and verify that the response is as expected.
