### PR TITLE
Implemented retrieve FAQs endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Faq.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Faq.java
@@ -1,0 +1,76 @@
+package COMP_49X_our_search.backend.database.entities;
+
+import COMP_49X_our_search.backend.database.enums.FaqType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "faqs")
+public class Faq {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String question;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String answer;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private FaqType faqType;
+
+  public Faq() {}
+
+  public Faq(
+      Integer id,
+      String question,
+      String answer,
+      FaqType faqType
+  ) {
+    this.id = id;
+    this.question = question;
+    this.answer = answer;
+    this.faqType = faqType;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getQuestion() {
+    return question;
+  }
+
+  public void setQuestion(String question) {
+    this.question = question;
+  }
+
+  public String getAnswer() {
+    return answer;
+  }
+
+  public void setAnswer(String answer) {
+    this.answer = answer;
+  }
+
+  public FaqType getFaqType() {
+    return faqType;
+  }
+
+  public void setFaqType(FaqType faqType) {
+    this.faqType = faqType;
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/enums/FaqType.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/enums/FaqType.java
@@ -1,0 +1,7 @@
+package COMP_49X_our_search.backend.database.enums;
+
+public enum FaqType {
+  STUDENT,
+  FACULTY,
+  ADMIN
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FaqRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/FaqRepository.java
@@ -1,0 +1,10 @@
+package COMP_49X_our_search.backend.database.repositories;
+
+import COMP_49X_our_search.backend.database.entities.Faq;
+import COMP_49X_our_search.backend.database.enums.FaqType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FaqRepository extends JpaRepository<Faq, Integer> {
+  List<Faq> findAllByFaqType(FaqType faqType);
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/FaqService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/FaqService.java
@@ -1,0 +1,23 @@
+package COMP_49X_our_search.backend.database.services;
+
+import COMP_49X_our_search.backend.database.entities.Faq;
+import COMP_49X_our_search.backend.database.enums.FaqType;
+import COMP_49X_our_search.backend.database.repositories.FaqRepository;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FaqService {
+
+  private final FaqRepository faqRepository;
+
+  @Autowired
+  public FaqService(FaqRepository faqRepository) {
+    this.faqRepository = faqRepository;
+  }
+
+  public List<Faq> getAllFaqsByType(FaqType faqType) {
+    return faqRepository.findAllByFaqType(faqType);
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -12,6 +12,7 @@
  */
 package COMP_49X_our_search.backend.gateway;
 
+import COMP_49X_our_search.backend.database.enums.FaqType;
 import java.util.ArrayList;
 import java.io.IOException;
 import java.util.Collections;
@@ -126,6 +127,7 @@ public class GatewayController {
   private final FacultyService facultyService;
   private final ProjectService projectService;
   private final EmailNotificationService emailNotificationService;
+  private final FaqService faqService;
 
   @Autowired
   public GatewayController(
@@ -140,7 +142,8 @@ public class GatewayController {
       StudentService studentService,
       FacultyService facultyService,
       ProjectService projectService,
-      EmailNotificationService emailNotificationService) {
+      EmailNotificationService emailNotificationService,
+      FaqService faqService) {
     this.moduleInvoker = moduleInvoker;
     this.oAuthChecker = oAuthChecker;
     this.departmentService = departmentService;
@@ -153,6 +156,7 @@ public class GatewayController {
     this.facultyService = facultyService;
     this.projectService = projectService;
     this.emailNotificationService = emailNotificationService;
+    this.faqService = faqService;
   }
 
   @GetMapping("/all-projects")
@@ -456,11 +460,14 @@ public class GatewayController {
                             .toList();
                     return new DisciplineDTO(discipline.getId(), discipline.getName(), majorDTOS);
                   })
-                  .collect(Collectors.toCollection(ArrayList::new)); //list must be mutable so we can add emptyDiscipline after
-      
-      List<MajorDTO> majorsWithoutDisciplines = majorService.getMajorsWithoutDisciplines().stream()
-        .map(major -> new MajorDTO(major.getId(), major.getName()))
-        .toList();
+              .collect(
+                  Collectors.toCollection(
+                      ArrayList::new)); // list must be mutable so we can add emptyDiscipline after
+
+      List<MajorDTO> majorsWithoutDisciplines =
+          majorService.getMajorsWithoutDisciplines().stream()
+              .map(major -> new MajorDTO(major.getId(), major.getName()))
+              .toList();
       DisciplineDTO emptyDiscipline = new DisciplineDTO(-1, "", majorsWithoutDisciplines);
       disciplineDTOS.add(emptyDiscipline);
       return ResponseEntity.ok(disciplineDTOS);
@@ -1290,5 +1297,32 @@ public class GatewayController {
             .toList();
 
     return ResponseEntity.ok(emailNotificationDTOS);
+  }
+
+  @GetMapping("/all-student-faqs")
+  public ResponseEntity<List<FaqDTO>> getStudentFaqs() {
+    return getFaqsByType(FaqType.STUDENT);
+  }
+
+  @GetMapping("/all-faculty-faqs")
+  public ResponseEntity<List<FaqDTO>> getFacultyFaqs() {
+    return getFaqsByType(FaqType.FACULTY);
+  }
+
+  @GetMapping("/all-admin-faqs")
+  public ResponseEntity<List<FaqDTO>> getAdminFaqs() {
+    return getFaqsByType(FaqType.ADMIN);
+  }
+
+  // Helper Methods
+  private ResponseEntity<List<FaqDTO>> getFaqsByType(FaqType type) {
+    List<Faq> faqs = faqService.getAllFaqsByType(type);
+
+    List<FaqDTO> faqDTOs =
+        faqs.stream()
+            .map(faq -> new FaqDTO(faq.getId(), faq.getQuestion(), faq.getAnswer()))
+            .toList();
+
+    return ResponseEntity.ok(faqDTOs);
   }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FaqDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FaqDTO.java
@@ -1,0 +1,40 @@
+package COMP_49X_our_search.backend.gateway.dto;
+
+public class FaqDTO {
+
+  private int id;
+  private String question;
+  private String answer;
+
+  public FaqDTO() {}
+
+  public FaqDTO(int id, String question, String answer) {
+    this.id = id;
+    this.question = question;
+    this.answer = answer;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public String getQuestion() {
+    return question;
+  }
+
+  public void setQuestion(String question) {
+    this.question = question;
+  }
+
+  public String getAnswer() {
+    return answer;
+  }
+
+  public void setAnswer(String answer) {
+    this.answer = answer;
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/FaqServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/FaqServiceTest.java
@@ -1,0 +1,65 @@
+package COMP_49X_our_search.backend.database;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import COMP_49X_our_search.backend.database.entities.Faq;
+import COMP_49X_our_search.backend.database.enums.FaqType;
+import COMP_49X_our_search.backend.database.repositories.FaqRepository;
+import COMP_49X_our_search.backend.database.services.FaqService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = {FaqService.class})
+@ActiveProfiles("test")
+public class FaqServiceTest {
+
+  @Autowired
+  private FaqService faqService;
+
+  @MockBean
+  private FaqRepository faqRepository;
+
+  @Test
+  void testGetAllStudentFaqs() {
+    Faq faq1 = new Faq(1, "What is OUR?", "OUR stands for Office of Undergraduate Research.", FaqType.STUDENT);
+    Faq faq2 = new Faq(2, "How do I apply?", "You can apply via the portal.", FaqType.STUDENT);
+
+    List<Faq> expectedFaqs = Arrays.asList(faq1, faq2);
+
+    when(faqRepository.findAllByFaqType(FaqType.STUDENT)).thenReturn(expectedFaqs);
+
+    List<Faq> result = faqService.getAllFaqsByType(FaqType.STUDENT);
+
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertTrue(result.contains(faq1));
+    assertTrue(result.contains(faq2));
+
+    verify(faqRepository, times(1)).findAllByFaqType(FaqType.STUDENT);
+  }
+
+  @Test
+  void testGetAllFacultyFaqs() {
+    Faq faq1 = new Faq(3, "How to post a project?", "Use the faculty dashboard.", FaqType.FACULTY);
+
+    List<Faq> expectedFaqs = List.of(faq1);
+
+    when(faqRepository.findAllByFaqType(FaqType.FACULTY)).thenReturn(expectedFaqs);
+
+    List<Faq> result = faqService.getAllFaqsByType(FaqType.FACULTY);
+
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertEquals(faq1, result.getFirst());
+
+    verify(faqRepository, times(1)).findAllByFaqType(FaqType.FACULTY);
+  }
+}


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added `GET` mappings at endpoints `all-student-faqs`, `all-faculty-faqs`, and `all-admin-faqs` to retrieve all FAQs by type.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

- Added new JPA Entity called `Faq` that will correspond to the `faqs` table with columns `id`, `question`, `answer`, and `type`.

### Object-Oriented Models

- Added JPA repository and service for the new `Faq` entity.
- Added new enum `FaqType` with possible values: `STUDENT`, `FACULTY`, `ADMIN`.

## End-to-End Testing Instructions

1. Make sure the frontend app, the backend app, and the mysql database are running and that there is valid faq data in the database.
2. Send `GET` request to endpoint `http://localhost:8080/all-student-faqs`, `http://localhost:8080/all-faculty-faqs`, and `http://localhost:8080/all-admin-faqs` and verify that the responses are as expected.