### PR TITLE
Fixed bugs editing projects, editing majors, and rendering majors/disciplines for admin on frontend

### DIFF
--- a/frontend/src/__tests__/MainAccordion.test.js
+++ b/frontend/src/__tests__/MainAccordion.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import MainAccordion from '../components/MainAccordion'
-import { errorLoadingPostingsMessage, noPostsMessage, viewFacultyFlag, viewStudentsFlag, viewProjectsFlag } from '../resources/constants'
+import { errorLoadingPostingsMessage, NO_MAJORS_MSG, viewFacultyFlag, viewStudentsFlag, viewProjectsFlag } from '../resources/constants'
 import { mockResearchOps, getAllFacultyExpectedResponse, mockStudents } from '../resources/mockData'
 
 describe('MainAccordion', () => {
@@ -65,8 +65,8 @@ describe('MainAccordion', () => {
       expect(screen.getByText('Discipline One')).toBeInTheDocument()
       expect(screen.getByText('Discipline Two')).toBeInTheDocument()
 
-      // For Discipline Two, since no majors exist, the noPostsMessage should appear.
-      expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
+      // For Discipline Two, since no majors exist, the NO_MAJORS_MSG should appear.
+      expect(screen.getByText(NO_MAJORS_MSG)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/__tests__/MainAccordion.test.js
+++ b/frontend/src/__tests__/MainAccordion.test.js
@@ -181,7 +181,7 @@ describe('MainAccordion', () => {
       // the first part of the mockData is a mock of a department with no faculty so the name will only appear once (0 faculty in the mockData)
       expect(screen.getAllByText(getAllFacultyExpectedResponse[0].name)).toHaveLength(1)
       // second department name appears 2 times because there is the title and 1 faculty in the mockdata
-      expect(screen.getAllByText(getAllFacultyExpectedResponse[1].name)).toHaveLength(2)
+      expect(screen.getAllByText(getAllFacultyExpectedResponse[2].name)).toHaveLength(2)
     })
   })
 })

--- a/frontend/src/__tests__/MainAccordion.test.js
+++ b/frontend/src/__tests__/MainAccordion.test.js
@@ -178,9 +178,9 @@ describe('MainAccordion', () => {
         />
       )
 
-      // first department name appears 3 times because there is the title and 2 projects in the mockdata
-      expect(screen.getAllByText(getAllFacultyExpectedResponse[0].name)).toHaveLength(3)
-      // second department name appears 2 times because there is the title and 1 project in the mockdata
+      // the first part of the mockData is a mock of a department with no faculty so the name will only appear once (0 faculty in the mockData)
+      expect(screen.getAllByText(getAllFacultyExpectedResponse[0].name)).toHaveLength(1)
+      // second department name appears 2 times because there is the title and 1 faculty in the mockdata
       expect(screen.getAllByText(getAllFacultyExpectedResponse[1].name)).toHaveLength(2)
     })
   })

--- a/frontend/src/__tests__/admin/view/AdminEmailNotification.test.js
+++ b/frontend/src/__tests__/admin/view/AdminEmailNotification.test.js
@@ -36,7 +36,7 @@ const mockFetch = (url, handlers) => {
 
 const fetchHandlers = [
   {
-    match: '/email-notifications', // For GET request to fetch current email templates
+    match: '/email-templates', // For GET request to fetch current email templates
     response: {
       ok: true,
       status: 200,
@@ -44,7 +44,7 @@ const fetchHandlers = [
     }
   },
   {
-    match: '/email-notifications', // For PUT request to update email templates
+    match: '/email-templates', // For PUT request to update email templates
     response: {
       ok: true,
       status: 200,

--- a/frontend/src/__tests__/admin/view/renderMajors.test.js
+++ b/frontend/src/__tests__/admin/view/renderMajors.test.js
@@ -77,7 +77,7 @@ describe('renderMajors Component', () => {
     const cancelButton = screen.getByTestId('cancel-major-btn')
     fireEvent.click(cancelButton)
 
-    expect(defaultProps.handleCancelMajorEdit).toHaveBeenCalledWith()
+    expect(defaultProps.handleCancelMajorEdit).toHaveBeenCalledWith(1)
   })
 
   it('should update new major name when input is changed', async () => {

--- a/frontend/src/__tests__/posts/PostList.test.js
+++ b/frontend/src/__tests__/posts/PostList.test.js
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import PostList from '../../components/posts/PostList'
 import { mockOneActiveProject, mockThreeActiveProjects, mockTwoInactiveProjects, mockOneFaculty, mockOneStudent } from '../../resources/mockData'
-import { noPostsMessage, viewStudentsFlag, viewProjectsFlag, viewFacultyFlag } from '../../resources/constants'
+import { NO_MAJORS_MSG, viewStudentsFlag, viewProjectsFlag, viewFacultyFlag } from '../../resources/constants'
 
 describe('PostList', () => {
   const mockSetSelectedPost = jest.fn()
@@ -24,7 +24,7 @@ describe('PostList', () => {
       />
     )
 
-    expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
+    expect(screen.getByText(NO_MAJORS_MSG)).toBeInTheDocument()
   })
 
   test('renders no postings message if there are no postings', () => {
@@ -39,7 +39,7 @@ describe('PostList', () => {
       />
     )
 
-    expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
+    expect(screen.getByText(NO_MAJORS_MSG)).toBeInTheDocument()
   })
 
   test('calls setSelectedPost when a card is clicked', async () => {
@@ -77,7 +77,7 @@ describe('PostList', () => {
         />
       )
 
-      expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
+      expect(screen.getByText(NO_MAJORS_MSG)).toBeInTheDocument()
     })
 
     it('renders active postings with correct details', () => {
@@ -143,7 +143,7 @@ describe('PostList', () => {
         />
       )
 
-      expect(screen.getByText(noPostsMessage)).toBeInTheDocument()
+      expect(screen.getByText(NO_MAJORS_MSG)).toBeInTheDocument()
     })
 
     it('renders active postings with correct details (faculty view is projects)', () => {

--- a/frontend/src/components/MainAccordion.js
+++ b/frontend/src/components/MainAccordion.js
@@ -23,7 +23,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
   const renderMajors = (discipline) => {
     if (discipline.majors.length === 0) {
       return (
-        <Typography style={{ padding: '16px' }}>
+        <Typography style={{ padding: '16px' }} bgcolor={'#F0F0F0'}>
           {noPostsMessage}
         </Typography>
       )

--- a/frontend/src/components/MainAccordion.js
+++ b/frontend/src/components/MainAccordion.js
@@ -23,7 +23,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
   const renderMajors = (discipline) => {
     if (discipline.majors.length === 0) {
       return (
-        <Typography style={{ padding: '16px' }} bgcolor={'#F0F0F0'}>
+        <Typography style={{ padding: '16px' }} bgcolor='#F0F0F0'>
           {noPostsMessage}
         </Typography>
       )

--- a/frontend/src/components/MainAccordion.js
+++ b/frontend/src/components/MainAccordion.js
@@ -14,7 +14,7 @@ import { Accordion, AccordionSummary, AccordionDetails, Typography, Box } from '
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import MajorAccordion from './MajorAccordion'
 import PostList from './posts/PostList'
-import { errorLoadingPostingsMessage, noPostsMessage, viewFacultyFlag } from '../resources/constants'
+import { errorLoadingPostingsMessage, NO_FACULTY_MSG, NO_MAJORS_MSG, viewFacultyFlag } from '../resources/constants'
 import PropTypes from 'prop-types'
 
 function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, postsView }) {
@@ -24,7 +24,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
     if (discipline.majors.length === 0) {
       return (
         <Typography style={{ padding: '16px' }} bgcolor='#F0F0F0'>
-          {noPostsMessage}
+          {NO_MAJORS_MSG}
         </Typography>
       )
     }
@@ -173,6 +173,12 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
               postsView={postsView}
             />
           </AccordionDetails>
+        )}
+
+        {department.faculty.length === 0 && (
+          <Typography style={{ padding: '16px' }} bgcolor='#F0F0F0'>
+            {NO_FACULTY_MSG}
+          </Typography>
         )}
       </Accordion>
     ))

--- a/frontend/src/components/admin/AdminEmailNotification.js
+++ b/frontend/src/components/admin/AdminEmailNotification.js
@@ -37,8 +37,9 @@ const AdminEmailNotifications = () => {
   useEffect(() => {
     const fetchTemplates = async () => {
       try {
-        const response = await fetch(`${backendUrl}/email-notifications`, {
-          credentials: 'include'
+        const response = await fetch(`${backendUrl}/email-templates`, {
+          credentials: 'include',
+          method: 'GET'
         })
         if (!response.ok) {
           throw new Error(`Error: ${response.statusText}`)
@@ -85,7 +86,7 @@ const AdminEmailNotifications = () => {
         { type: 'STUDENTS', subject: templates.STUDENTS.subject, body: templates.STUDENTS.body },
         { type: 'FACULTY', subject: templates.FACULTY.subject, body: templates.FACULTY.body }
       ]
-      const response = await fetch(`${backendUrl}/email-notifications`, {
+      const response = await fetch(`${backendUrl}/email-templates`, {
         method: 'PUT',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/components/admin/ManageVariables.js
+++ b/frontend/src/components/admin/ManageVariables.js
@@ -379,8 +379,16 @@ function ManageVariables ({
           Here you can manage the data included in the OUR SEARCH app.
         </Typography>
         <Typography sx={{ padding: 2 }} color='red'>
-          Instructions: edit variable names, add new variables, and delete variables.
-          Note that you cannot remove ... if there are projects, students, or faculty currently attached to it.
+          Instructions:
+          To edit variables, click the pencil icon on the right. Once edited, click Save.
+          To delete variables, click the trash icon on the right.
+          To add new variables, fill in the input boxes on the bottom. Then click Add.
+        </Typography>
+        <Typography sx={{ padding: 2 }} color='red'>
+          Note that you cannot remove umbrella topics, research periods, or majors if there are already projects, students, or faculty currently attached to them. You must delete those connections first.
+          By deleting a department, any faculty previously associated with that department will no longer be associated with it.
+          "Other" encapsulates majors that are not under a discipline.
+          You cannot edit the Undeclared major.
         </Typography>
       </Box>
       <Box sx={{ padding: 1, maxWidth: 900, margin: 'auto' }} display='flex' justifyContent='center' alignItems='center'>

--- a/frontend/src/components/admin/ManageVariables.js
+++ b/frontend/src/components/admin/ManageVariables.js
@@ -67,12 +67,12 @@ function ManageVariables ({
   const [deletingIdDiscipline, setDeletingIdDiscipline] = useState(null)
 
   // majors
-  const [majors, setMajors] = useState([])
+  const [majors, setMajors] = useState([]) // array of majors with their disciplines
   const [editingIdMajor, setEditingIdMajor] = useState(null)
   const [editedNameMajor, setEditedNameMajor] = useState('')
-  const [selectedDisciplines, setSelectedDisciplines] = useState({})
+  const [selectedDisciplines, setSelectedDisciplines] = useState({}) // dict of majorId with discipline(s) each major is under. Used to prepopulate discipline dropdowns.
   const [newMajorName, setNewMajorName] = useState('')
-  const [newMajorDisciplines, setNewMajorDisciplines] = useState([])
+  const [newMajorDisciplines, setNewMajorDisciplines] = useState([]) // array of strings sent in backend request for editing and adding a major
   const [deletingIdMajor, setDeletingIdMajor] = useState(null)
 
   // umbrella topics
@@ -143,18 +143,23 @@ function ManageVariables ({
     })
 
     setMajors(Object.values(majorMap)) // converts values into an array
-    // with key: majorId, value: object containing major id, name, disciplines (array of discipline objects with id, name, majors)
-    // ex: { 1: { id: 1, name: 'major name', disciplines: [ {id, name, majors ...} ]}}
+    // majorMap has key: majorId, value: object containing major id, name, disciplines (array of discipline objects with id, name, majors)
+    // ex: { 1: {id: 1, name: 'major name', disciplines: [{id, name, majors ...}]}, ...}
+    // majors is just [ {id, name, disciplines}, {...}, ... ]
 
     // Prepopulate discipline selections per major
     // key: majorId, value: object with disciplineId, disciplineName, list of majors
     const prepopulatedMajorDisciplines = {}
     Object.values(majorMap).forEach(major => {
-      if (major.disciplines.length === 1 && major.disciplines[0].id === -1) { // (-1 is for majors with no discipline)
-        prepopulatedMajorDisciplines[major.id] = []
-      } else {
-        prepopulatedMajorDisciplines[major.id] = major.disciplines
-      }
+      // this makes the discipline drop-down empty if under "Other"
+      // if (major.disciplines.length === 1 && major.disciplines[0].id === -1) { // (-1 is for majors with no discipline)
+      // prepopulatedMajorDisciplines[major.id] = []
+      // } else {
+      //   prepopulatedMajorDisciplines[major.id] = major.disciplines
+      // }
+
+      // this makes the discipline drop-down show "Other" as the preselected "discipline"
+      prepopulatedMajorDisciplines[major.id] = major.disciplines
     })
 
     setSelectedDisciplines(prepopulatedMajorDisciplines)
@@ -225,6 +230,7 @@ function ManageVariables ({
     setEditedNameMajor(name)
   }
 
+  // Cancel MAJOR Edit is the only Cancel Edit function that needs an id because majors have disciplines associated
   const handleCancelMajorEdit = (id) => {
     setSelectedDisciplines(prev => ({ // Set the disciplines back to what they originally were
       ...prev,
@@ -367,12 +373,23 @@ function ManageVariables ({
         )}
 
       </Box>
-      <Box sx={{ padding: 2, maxWidth: 900, margin: 'auto' }}>
+      <Box sx={{ padding: 3, maxWidth: 900, margin: 'auto' }}>
         <Typography variant='body1'>
           <InfoIcon />
           Here you can manage the data included in the OUR SEARCH app.
-          Instructions: Edit variable names, add new variables, and delete variables. Note that you cannot remove if there are projects, students, or faculty currently attached to it.
         </Typography>
+        <Typography sx={{ padding: 2 }} color='red'>
+          Instructions: edit variable names, add new variables, and delete variables.
+          Note that you cannot remove ... if there are projects, students, or faculty currently attached to it.
+        </Typography>
+      </Box>
+      <Box sx={{ padding: 1, maxWidth: 900, margin: 'auto' }} display='flex' justifyContent='center' alignItems='center'>
+        <Button onClick={() => navigate('/disciplines-and-majors')}>Disciplines</Button>
+        <Button onClick={() => navigate('/disciplines-and-majors')}>Majors</Button>
+        <Button onClick={() => navigate('/other-app-vars')}>Research Periods</Button>
+        <Button onClick={() => navigate('/other-app-vars')}>Umbrella Topics</Button>
+        <Button onClick={() => navigate('/other-app-vars')}>Departments</Button>
+        <Button onClick={() => navigate('/admin-faqs')}>FAQs</Button>
       </Box>
       {showingDisciplinesAndMajors && renderDisciplines({
         loadingDisciplinesMajors,

--- a/frontend/src/components/admin/RenderAdminVariables.js
+++ b/frontend/src/components/admin/RenderAdminVariables.js
@@ -229,7 +229,7 @@ export const renderMajors = ({
                   variant='outlined'
                   color='warning'
                   startIcon={<Cancel />}
-                  onClick={() => handleCancelMajorEdit()}
+                  onClick={() => handleCancelMajorEdit(id)}
                   data-testid='cancel-major-btn'
                 >
                   Cancel

--- a/frontend/src/components/admin/RenderAdminVariables.js
+++ b/frontend/src/components/admin/RenderAdminVariables.js
@@ -184,7 +184,7 @@ export const renderMajors = ({
               <Autocomplete
                 multiple
                 sx={{ width: '60%' }}
-                options={disciplines.filter(disc => disc.id !== -1)}
+                options={disciplines} // add .filter(disc => disc.id !== -1) to remove "Other" from the dropdowns
                 getOptionLabel={(option) => option.name}
                 value={selectedDisciplines[id] || []}
                 onChange={(_, newValue) => setSelectedDisciplines({ ...selectedDisciplines, [id]: newValue })}

--- a/frontend/src/components/navigation/SharedLayout.js
+++ b/frontend/src/components/navigation/SharedLayout.js
@@ -103,8 +103,8 @@ const SharedLayout = ({ isStudent = false, isFaculty = false, isAdmin = false, h
       </Box>
       {!showingPosts && children}
 
-    {/* extra padding above the bottom navigation so nothing gets cut off by the bottom nav */}
-      <Box sx={{mb:20}}></Box> 
+      {/* extra padding above the bottom navigation so nothing gets cut off by the bottom nav */}
+      <Box sx={{ mb: 20 }} />
 
       <BottomNavigation
         showLabels

--- a/frontend/src/components/navigation/SharedLayout.js
+++ b/frontend/src/components/navigation/SharedLayout.js
@@ -23,7 +23,6 @@ const iconColor = '#0189ce'
 const SharedLayout = ({ isStudent = false, isFaculty = false, isAdmin = false, handleLogout, showingPosts = false, children }) => {
   const navigate = useNavigate()
   const [open, setOpen] = useState(true) // by default should be open
-  const [bottomNavValue, setBottomNavValue] = useState(0)
 
   const toggleDrawer = () => {
     setOpen(!open)
@@ -104,11 +103,10 @@ const SharedLayout = ({ isStudent = false, isFaculty = false, isAdmin = false, h
       </Box>
       {!showingPosts && children}
 
+    {/* extra padding above the bottom navigation so nothing gets cut off by the bottom nav */}
+      <Box sx={{mb:20}}></Box> 
+
       <BottomNavigation
-        value={bottomNavValue}
-        onChange={(event, newValue) => {
-          setBottomNavValue(newValue)
-        }}
         showLabels
         sx={{
           width: '100%',

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -141,7 +141,7 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = 
   if (showMyOwnProject) {
     return (
       <>
-        <DialogTheme open={!!post} onClose={() => navigate('/view-professor-profile')} title={post.name}>
+        <DialogTheme open={!!post} onClose={onClose} title={post.name}>
           <ProjectEdit isFaculty myFacultyProjectId={myProjectId} />
         </DialogTheme>
       </>

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -142,7 +142,7 @@ const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = 
     return (
       <>
         <DialogTheme open={!!post} onClose={() => navigate('/view-professor-profile')} title={post.name}>
-          <ProjectEdit isFaculty myProjectId={myProjectId} />
+          <ProjectEdit isFaculty myFacultyProjectId={myProjectId} />
         </DialogTheme>
       </>
     )

--- a/frontend/src/components/posts/PostList.js
+++ b/frontend/src/components/posts/PostList.js
@@ -22,7 +22,7 @@ import EmailIcon from '@mui/icons-material/Email'
 import SchoolIcon from '@mui/icons-material/School'
 import DomainIcon from '@mui/icons-material/Domain'
 import LightbulbIcon from '@mui/icons-material/Lightbulb'
-import { noPostsMessage, viewProjectsFlag, viewStudentsFlag, viewFacultyFlag } from '../../resources/constants'
+import { NO_MAJORS_MSG, viewProjectsFlag, viewStudentsFlag, viewFacultyFlag } from '../../resources/constants'
 import PropTypes from 'prop-types'
 
 function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, postsView, isOnFacultyProfile }) {
@@ -37,7 +37,7 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, p
   if (postsToDisplay.length === 0) {
     return (
       <Box sx={{ p: 2 }}>
-        <Typography sx={{ p: 2 }}>{noPostsMessage}</Typography>
+        <Typography sx={{ p: 2 }}>{NO_MAJORS_MSG}</Typography>
       </Box>
     )
   }
@@ -318,7 +318,7 @@ function PostList ({ postings, setSelectedPost, isStudent, isFaculty, isAdmin, p
   } else {
     return (
       <Box sx={{ p: 2 }}>
-        <Typography sx={{ p: 2 }}>{noPostsMessage}</Typography>
+        <Typography sx={{ p: 2 }}>{NO_MAJORS_MSG}</Typography>
       </Box>
     )
   }

--- a/frontend/src/components/projects/ProjectEdit.js
+++ b/frontend/src/components/projects/ProjectEdit.js
@@ -89,7 +89,6 @@ const ProjectEdit = ({ isFaculty = false, myFacultyProjectId = null }) => {
         majors // Include the selected majors
       }
     })
-    console.log('toReturn :>> ', toReturn)
     return toReturn
   }
   // Updates the form data to include the selected majors and their associated discipline

--- a/frontend/src/components/projects/ProjectEdit.js
+++ b/frontend/src/components/projects/ProjectEdit.js
@@ -1,5 +1,3 @@
-// TODO move research opportunity form to /projects
-
 /**
  * This component fetches the current project's data, allows the admin
  * to edit the project information and submits the updated data to the backend.
@@ -75,26 +73,36 @@ const ProjectEdit = ({ isFaculty = false, myFacultyProjectId = null }) => {
   const [submitting, setSubmitting] = useState(false)
   const [formErrors, setFormErrors] = useState({})
   const [submitSuccess, setSubmitSuccess] = useState(false)
-  const [selectedMajors, setSelectedMajors] = useState({})
+  const [selectedMajors, setSelectedMajors] = useState({}) // key: disciplineId, value: list of major objects {id, name}
 
+  // Creates a list for the PUT /project expected request body.
+  // That is, a list of each discipline {id: x, name: disciplineName, majors: [...]}
+  // where majors:[...] is a list of majors for this project
+  const getDisciplinesToReturn = (selected) => {
+    const toReturn = disciplineOptions.map(discipline => {
+      // For each discipline, check if this discipline has selected majors
+      const majors = selected[discipline.id] || []
+
+      return {
+        id: discipline.id,
+        name: discipline.name, // Include the name of the discipline
+        majors // Include the selected majors
+      }
+    })
+    console.log('toReturn :>> ', toReturn)
+    return toReturn
+  }
   // Updates the form data to include the selected majors and their associated discipline
   const handleMajorChange = (disciplineId, event) => {
     const newSelectedMajors = { ...selectedMajors, [disciplineId]: event.target.value }
 
     setSelectedMajors(newSelectedMajors)
 
+    const disciplinesToReturn = getDisciplinesToReturn(newSelectedMajors)
+
     setFormData({
       ...formData,
-      disciplines: disciplineOptions.map(discipline => {
-        // Check if this discipline has selected majors
-        const selectedMajors = newSelectedMajors[discipline.id] || []
-
-        return {
-          id: discipline.id,
-          name: discipline.name, // Include the name of the discipline
-          majors: selectedMajors // Include the selected majors
-        }
-      })
+      disciplines: disciplinesToReturn
     })
   }
 
@@ -184,6 +192,7 @@ const ProjectEdit = ({ isFaculty = false, myFacultyProjectId = null }) => {
     })
   }
 
+  // Handle Select changes
   const handleMultiSelectChange = (event, fieldName) => {
   // when invoked, the fieldName must match the formData field name, written as a string,
   // e.g. fieldName='researchPeriods' if the formData has a formData.researchPeriods field.
@@ -223,6 +232,13 @@ const ProjectEdit = ({ isFaculty = false, myFacultyProjectId = null }) => {
       setSubmitting(true)
       setFormErrors({})
 
+      const disciplinesToReturn = getDisciplinesToReturn(selectedMajors)
+
+      const formDataWithDisciplines = {
+        ...formData,
+        disciplines: disciplinesToReturn
+      }
+
       try {
         const response = await fetch(`${backendUrl}/project`, {
           method: 'PUT',
@@ -230,7 +246,7 @@ const ProjectEdit = ({ isFaculty = false, myFacultyProjectId = null }) => {
           headers: {
             'Content-Type': 'application/json'
           },
-          body: JSON.stringify(formData)
+          body: JSON.stringify(formDataWithDisciplines)
         })
         if (!response.ok) {
           throw new Error(`Error: ${response.statusText}`)

--- a/frontend/src/resources/constants.js
+++ b/frontend/src/resources/constants.js
@@ -3,7 +3,7 @@ export const appTitle = 'OUR SEARCH'
 export const customBlueColor = '#A7C7E7'
 
 export const errorLoadingPostingsMessage = 'Sorry, there was an error loading site data. Try again later.'
-export const noPostsMessage = 'None available'
+export const noPostsMessage = 'No research fields available'
 
 export const viewStudentsFlag = 'students'
 export const viewProjectsFlag = 'projects'

--- a/frontend/src/resources/constants.js
+++ b/frontend/src/resources/constants.js
@@ -3,7 +3,8 @@ export const appTitle = 'OUR SEARCH'
 export const customBlueColor = '#A7C7E7'
 
 export const errorLoadingPostingsMessage = 'Sorry, there was an error loading site data. Try again later.'
-export const noPostsMessage = 'No research fields available'
+export const NO_MAJORS_MSG = 'No research fields available'
+export const NO_FACULTY_MSG = 'No faculty available'
 
 export const viewStudentsFlag = 'students'
 export const viewProjectsFlag = 'projects'

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -217,6 +217,20 @@ export const mockStudents = [
 // expected response from GET /all-projects
 export const mockResearchOps = [
   {
+    id: -1,
+    name: 'Other',
+    majors: [{
+      id: 9,
+      name: 'Undeclared',
+      posts: []
+    }]
+  },
+  {
+    id: 7,
+    name: 'Discipline with no majors',
+    majors: []
+  },
+  {
     id: 1,
     name: 'Engineering',
     majors: [
@@ -444,8 +458,8 @@ export const mockDisciplinesMajors = [
   },
   {
     id: -1,
-    name: '',
-    majors: [{ id: 7, name: 'major no discipline' }, { id: 8, name: 'another major' }]
+    name: 'Other',
+    majors: [{ id: 7, name: 'Undeclared' }, { id: 8, name: 'Another test major no discipline' }]
   }
 ]
 export const getMajorsExpectedResponse = [{ id: 1, name: 'Computer Science' }, { id: 2, name: 'Chemistry' }, { id: 3, name: 'Data Science' }]

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -712,6 +712,11 @@ export const createResearchPeriodExpectedRequest = {
 // GET response /all-faculty
 export const getAllFacultyExpectedResponse = [
   {
+    id: 6,
+    name: 'Department with no faculty',
+    faculty: []
+  },
+  {
     id: 4,
     name: 'Chemistry',
     faculty: [


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fixes

**Summary:** 
- faculty can now click edit project to see their project
- faculty closing edit project view now works
- bottom nav bar has padding to not be in the way
- disciplines with no majors show up with "no research fields available"
- on admin page, majors with no discipline show "Other" as preselected "discipline" but sending an edit or add request without any discipline selected still works
- email notification page now requests from correct endpoint

## UI/UX Implementation
Nothing changed about original plan; this PR corrects errors. 
