### PR TITLE
Changed frontend to look for "Other" discipline by name instead of id

### DIFF
--- a/frontend/src/components/admin/ManageVariables.js
+++ b/frontend/src/components/admin/ManageVariables.js
@@ -152,7 +152,7 @@ function ManageVariables ({
     const prepopulatedMajorDisciplines = {}
     Object.values(majorMap).forEach(major => {
       // this makes the discipline drop-down empty if under "Other"
-      // if (major.disciplines.length === 1 && major.disciplines[0].id === -1) { // (-1 is for majors with no discipline)
+      // if (major.disciplines.length === 1 && major.disciplines[0].name === 'Other') {
       // prepopulatedMajorDisciplines[major.id] = []
       // } else {
       //   prepopulatedMajorDisciplines[major.id] = major.disciplines
@@ -234,7 +234,7 @@ function ManageVariables ({
   const handleCancelMajorEdit = (id) => {
     setSelectedDisciplines(prev => ({ // Set the disciplines back to what they originally were
       ...prev,
-      [id]: majors.find(m => m.id === id)?.disciplines[0].id !== -1 ? majors.find(m => m.id === id)?.disciplines : [] // set selected disciplines to empty array if the major previously had no discipline (id was -1)
+      [id]: majors.find(m => m.id === id)?.disciplines[0].name !== 'Other' ? majors.find(m => m.id === id)?.disciplines : [] // set selected disciplines to empty array if the major previously had no discipline
     }))
     setEditingIdMajor(null) // Stop editting this major
     setEditedNameMajor('')

--- a/frontend/src/components/admin/RenderAdminVariables.js
+++ b/frontend/src/components/admin/RenderAdminVariables.js
@@ -44,7 +44,7 @@ export const renderDisciplines = ({
       <Typography variant='h5' gutterBottom>Disciplines</Typography>
       <List>
         {disciplines
-          .filter((disc) => disc.id !== -1)
+          .filter((disc) => disc.name !== 'Other')
           .map(({ id, name }) => (
             <ListItem key={id} sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', gap: 1 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', gap: editingIdDiscipline === id ? '10px' : '0px' }}>
@@ -184,7 +184,7 @@ export const renderMajors = ({
               <Autocomplete
                 multiple
                 sx={{ width: '60%' }}
-                options={disciplines} // add .filter(disc => disc.id !== -1) to remove "Other" from the dropdowns
+                options={disciplines} // add .filter(disc => disc.name !== 'Other) to remove "Other" from the dropdowns
                 getOptionLabel={(option) => option.name}
                 value={selectedDisciplines[id] || []}
                 onChange={(_, newValue) => setSelectedDisciplines({ ...selectedDisciplines, [id]: newValue })}


### PR DESCRIPTION
# Overview

**Type of Change:** Refactor

**Summary:** Decided to filter for the "Other" discipline on the frontend by filtering for `name` field rather than 'id` field. This is because we have decided to create a whole new discipline in the db called "Other". Any request to edit disciplines won't be able to change the name of it, so it's name will always be unique and able to find. Also, we can't set the id to -1 so we can't check based on the id. 