### PR TITLE
Added support for "Other" discipline and "Undeclared" major

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Discipline.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Discipline.java
@@ -25,7 +25,7 @@ public class Discipline {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String name;
 
   @ManyToMany(mappedBy = "disciplines")

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Major.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/entities/Major.java
@@ -32,7 +32,7 @@ public class Major {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Integer id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String name;
 
   @ManyToMany

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/MajorService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/MajorService.java
@@ -8,11 +8,17 @@
  */
 package COMP_49X_our_search.backend.database.services;
 
+import COMP_49X_our_search.backend.database.entities.Discipline;
 import COMP_49X_our_search.backend.database.entities.Major;
 import COMP_49X_our_search.backend.database.repositories.MajorRepository;
 
+import COMP_49X_our_search.backend.util.Constants;
+import COMP_49X_our_search.backend.util.exceptions.ForbiddenMajorActionException;
+import jakarta.annotation.PostConstruct;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -22,10 +28,42 @@ import org.springframework.transaction.annotation.Transactional;
 public class MajorService {
 
   private final MajorRepository majorRepository;
+  private final DisciplineService disciplineService;
 
   @Autowired
-  public MajorService(MajorRepository majorRepository) {
+  public MajorService(MajorRepository majorRepository, DisciplineService disciplineService) {
     this.majorRepository = majorRepository;
+    this.disciplineService = disciplineService;
+  }
+
+  @PostConstruct
+  public void initializeSpecialMajors() {
+    if (majorRepository.findMajorByName(Constants.MAJOR_UNDECLARED).isEmpty()) {
+      Major undeclaredMajor = new Major(Constants.MAJOR_UNDECLARED);
+
+      Discipline otherDiscipline = disciplineService.getOtherDiscipline();
+      Set<Discipline> disciplines = new HashSet<>();
+      disciplines.add(otherDiscipline);
+      undeclaredMajor.setDisciplines(disciplines);
+
+      majorRepository.save(undeclaredMajor);
+    }
+  }
+
+  public Major getUndeclaredMajor() {
+    return majorRepository
+        .findMajorByName(Constants.MAJOR_UNDECLARED)
+        .orElseGet(
+            () -> {
+              Major undeclaredMajor = new Major(Constants.MAJOR_UNDECLARED);
+
+              Discipline otherDiscipline = disciplineService.getOtherDiscipline();
+              Set<Discipline> disciplines = new HashSet<>();
+              disciplines.add(otherDiscipline);
+              undeclaredMajor.setDisciplines(disciplines);
+
+              return majorRepository.save(undeclaredMajor);
+            });
   }
 
   public List<Major> getAllMajors() {
@@ -47,15 +85,77 @@ public class MajorService {
   }
 
   public Major saveMajor(Major major) {
+    // If id != null it means we're trying to edit an existing major
+    if (major.getId() != null) {
+      throw new IllegalArgumentException("Major id provided. For existing majors, use editMajor instead.");
+    }
+
+    // If id is null, it means we're trying to create a new major.
+    if (major.getName().equals(Constants.MAJOR_UNDECLARED)) {
+      throw new ForbiddenMajorActionException(
+          "Creating a major with name 'Undeclared' is not allowed.");
+    }
+
+    Set<Discipline> disciplines = major.getDisciplines();
+    Discipline otherDiscipline = disciplineService.getOtherDiscipline();
+
+    // If the list of disciplines is empty, the major is associated with the
+    // "Other" discipline by default.
+    if (disciplines.isEmpty()) {
+      disciplines = new HashSet<>();
+      disciplines.add(otherDiscipline);
+    }
+    // If the list of disciplines is not empty AND it contains the "Other"
+    // discipline, it should ignore the "Other" discipline, since it will only
+    // be used for the "Undeclared" major and majors that don't currently belong
+    // to any discipline.
+    else if (disciplines.size() > 1) {
+      disciplines.remove(otherDiscipline);
+    }
+
+    major.setDisciplines(disciplines);
+
+    return majorRepository.save(major);
+  }
+
+  @Transactional
+  public Major editMajor(int id, String newName, Set<Discipline> disciplines) {
+    Major major = getMajorById(id);
+    if (major.getName().equals(Constants.MAJOR_UNDECLARED)) {
+      throw new ForbiddenMajorActionException("Editing major 'Undeclared' is not allowed.");
+    }
+
+    major.setName(newName);
+
+    Discipline otherDiscipline = disciplineService.getOtherDiscipline();
+
+    // If no disciplines are provided, add major to "Other" by default.
+    if (disciplines.isEmpty()) {
+      disciplines = new HashSet<>();
+      disciplines.add(otherDiscipline);
+    }
+    // If disciplines are provided as well as "Other", remove "Other"
+    else if (disciplines.size() > 1) {
+      disciplines.remove(otherDiscipline);
+    }
+
+    major.setDisciplines(disciplines);
     return majorRepository.save(major);
   }
 
   @Transactional
   public void deleteMajorById(int id) {
-    Major major = majorRepository.findById(id)
-        .orElseThrow(() -> new RuntimeException(
-            String.format("Cannot delete major with id '%s'. Major not found.", id)
-        ));
+    Major major =
+        majorRepository
+            .findById(id)
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        String.format("Cannot delete major with id '%s'. Major not found.", id)));
+
+    if (major.getName().equals(Constants.MAJOR_UNDECLARED)) {
+      throw new ForbiddenMajorActionException("Deleting major 'Undeclared' is not allowed.");
+    }
 
     if (!major.getStudents().isEmpty()) {
       throw new IllegalStateException("Major has students associated with it, cannot delete");

--- a/backend/src/main/java/COMP_49X_our_search/backend/util/Constants.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/util/Constants.java
@@ -1,0 +1,12 @@
+package COMP_49X_our_search.backend.util;
+
+public class Constants {
+  public static final String DISCIPLINE_OTHER = "Other";
+  public static final String MAJOR_UNDECLARED = "Undeclared";
+  public static final int DISCIPLINE_OTHER_FRONTEND_ID = -1;
+  public static final int MAJOR_UNDECLARED_FRONTEND_ID = -1;
+
+  private Constants() {
+    throw new UnsupportedOperationException("Constants class cannot be instantiated.");
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/util/exceptions/ForbiddenDisciplineActionException.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/util/exceptions/ForbiddenDisciplineActionException.java
@@ -1,0 +1,8 @@
+package COMP_49X_our_search.backend.util.exceptions;
+
+public class ForbiddenDisciplineActionException extends RuntimeException {
+
+  public ForbiddenDisciplineActionException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/main/java/COMP_49X_our_search/backend/util/exceptions/ForbiddenMajorActionException.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/util/exceptions/ForbiddenMajorActionException.java
@@ -1,0 +1,8 @@
+package COMP_49X_our_search.backend.util.exceptions;
+
+public class ForbiddenMajorActionException extends RuntimeException {
+
+  public ForbiddenMajorActionException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -566,19 +566,16 @@ public class GatewayControllerTest {
     Major major1 = new Major(1, "Computer Science");
     Major major2 = new Major(2, "Math");
     Major major3 = new Major(3, "Drawing");
-    Major major4 = new Major(4, "I dont have a discipline");
     when(majorService.getMajorsByDisciplineId(discipline1.getId()))
         .thenReturn(List.of(major1, major2));
     when(majorService.getMajorsByDisciplineId(discipline2.getId())).thenReturn(List.of(major3));
-    when(majorService.getMajorsWithoutDisciplines()).thenReturn(List.of(major4));
 
     mockMvc
         .perform(get("/disciplines"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.length()").value(3))
+        .andExpect(jsonPath("$.length()").value(2))
         .andExpect(jsonPath("$[0].id").value(discipline1.getId()))
         .andExpect(jsonPath("$[1].id").value(discipline2.getId()))
-        .andExpect(jsonPath("$[2].id").value(-1)) // add on -1 reference for majors with no disciplines
         .andExpect(jsonPath("$[0].name").value(discipline1.getName()))
         .andExpect(jsonPath("$[1].name").value(discipline2.getName()))
         .andExpect(jsonPath("$[0].majors.length()").value(2))
@@ -588,8 +585,7 @@ public class GatewayControllerTest {
         .andExpect(jsonPath("$[0].majors[1].name").value(major2.getName()))
         .andExpect(jsonPath("$[1].majors.length()").value(1))
         .andExpect(jsonPath("$[1].majors[0].id").value(major3.getId()))
-        .andExpect(jsonPath("$[1].majors[0].name").value(major3.getName()))
-        .andExpect(jsonPath("$[2].majors[0].name").value(major4.getName()));
+        .andExpect(jsonPath("$[1].majors[0].name").value(major3.getName()));
   }
 
   @Test
@@ -1171,7 +1167,7 @@ public class GatewayControllerTest {
     when(majorService.getMajorById(majorId)).thenReturn(originalMajor);
     when(disciplineService.getDisciplineByName("Life and Physical Sciences"))
         .thenReturn(newDiscipline);
-    when(majorService.saveMajor(any(Major.class))).thenReturn(updatedMajor);
+    when(majorService.editMajor(eq(majorId), eq("Data Science"), any(Set.class))).thenReturn(updatedMajor);
 
     mockMvc
         .perform(
@@ -1186,7 +1182,7 @@ public class GatewayControllerTest {
 
     verify(majorService, times(1)).getMajorById(majorId);
     verify(disciplineService, times(1)).getDisciplineByName("Life and Physical Sciences");
-    verify(majorService, times(1)).saveMajor(any(Major.class));
+    verify(majorService, times(1)).editMajor(eq(majorId), eq("Data Science"), any(Set.class));
   }
 
   @Test
@@ -1340,7 +1336,7 @@ public class GatewayControllerTest {
     DisciplineDTO requestDTO = new DisciplineDTO(1, "New Name", null);
 
     when(disciplineService.getDisciplineById(1)).thenReturn(existingDiscipline);
-    when(disciplineService.saveDiscipline(any(Discipline.class))).thenReturn(updatedDiscipline);
+    when(disciplineService.editDiscipline(1, "New Name")).thenReturn(updatedDiscipline);
     when(majorService.getMajorsByDisciplineId(1)).thenReturn(List.of(major1, major2));
 
     mockMvc
@@ -1357,8 +1353,7 @@ public class GatewayControllerTest {
         .andExpect(jsonPath("$.majors[1].id").value(20))
         .andExpect(jsonPath("$.majors[1].name").value("Math"));
 
-    verify(disciplineService, times(1)).getDisciplineById(1);
-    verify(disciplineService, times(1)).saveDiscipline(any(Discipline.class));
+    verify(disciplineService, times(1)).editDiscipline(1, "New Name");
     verify(majorService, times(1)).getMajorsByDisciplineId(1);
   }
 


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature / Refactoring.

**Summary:** Logic changes for the special cases of the `Discipline` and `Major` JPA entities, specifically for the `"Other"` discipline and the `"Undeclared"` major. These changes make sure that:
 - The special cases are created automatically if they don't exist.
 - Cannot be manually created, edited, or deleted by users.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

- Updated `"Discipline"` and `"Major"` entities to make the `name` field unique.
- Added auto-initialization of special entries "Other" for disciplines and "Undeclared" for majors added in `@PostConstruct`.

### Object-Oriented Models

- Updated `DisciplineService` and `MajorService` with new auto-initialization methods: `initializeSpecialDisciplines()` and `initializeSpecialMajors()` for the special cases.
- Added validation logic in existing `save`/`edit`/`delete` methods to prevent modifying these special cases.
- Added to new exception classes: `ForbiddenDisciplineActionException` and `ForbiddenMajorActionException` that will be used to determine whether `FORBIDDEN` should be sent to the frontend.

## End-to-End Testing Instructions

### Discipline
1) `"Other"` auto-initialization
- Delete all entries from the `disciplines` table
- Restart app
- Verify that `"Other"` was automatically created
2) Prevent modifying `"Other"`
- Try to POST/PUT/DELETE a discipline with name `"Other"` should return `403 Forbidden`

### Major
1) `"Undeclared"` auto-initialization
- Delete all entries from the `majors` table
- Restart app
- Verify that `"Undeclared"` was automatically created
2) Prevent modifying `"Undeclared"`
- Try to POST/PUT/DELETE a discipline with name `"Undeclared"` should return `403 Forbidden`
