### PR TITLE
Implement create FAQ endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/FaqService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/FaqService.java
@@ -20,4 +20,8 @@ public class FaqService {
   public List<Faq> getAllFaqsByType(FaqType faqType) {
     return faqRepository.findAllByFaqType(faqType);
   }
+
+  public Faq saveFaq(Faq faq) {
+    return faqRepository.save(faq);
+  }
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -1315,6 +1315,36 @@ public class GatewayController {
     return getFaqsByType(FaqType.ADMIN);
   }
 
+  @PostMapping("/faq")
+  public ResponseEntity<FaqRequestDTO> createFaq(@RequestBody FaqRequestDTO requestBody) {
+    try {
+      if (requestBody.getType() == null ||
+          requestBody.getQuestion() == null ||
+          requestBody.getAnswer() == null) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+      }
+
+      Faq faqToSave = new Faq(
+          null,
+          requestBody.getQuestion(),
+          requestBody.getAnswer(),
+          requestBody.getType()
+      );
+
+      Faq savedFaq = faqService.saveFaq(faqToSave);
+
+      FaqRequestDTO response = new FaqRequestDTO(
+          savedFaq.getId(),
+          savedFaq.getFaqType(),
+          savedFaq.getQuestion(),
+          savedFaq.getAnswer()
+      );
+      return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
   // Helper Methods
   private ResponseEntity<List<FaqDTO>> getFaqsByType(FaqType type) {
     List<Faq> faqs = faqService.getAllFaqsByType(type);

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FaqRequestDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/FaqRequestDTO.java
@@ -1,0 +1,51 @@
+package COMP_49X_our_search.backend.gateway.dto;
+
+import COMP_49X_our_search.backend.database.enums.FaqType;
+
+public class FaqRequestDTO {
+  private int id; // Required for PUT, DELETE
+  private FaqType type; // Required for POST
+  private String question; // Required for POST, PUT
+  private String answer;   // Required for POST, PUT
+
+  public FaqRequestDTO() {}
+
+  public FaqRequestDTO(int id, FaqType type, String question, String answer) {
+    this.id = id;
+    this.type = type;
+    this.question = question;
+    this.answer = answer;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public FaqType getType() {
+    return type;
+  }
+
+  public void setType(FaqType type) {
+    this.type = type;
+  }
+
+  public String getQuestion() {
+    return question;
+  }
+
+  public void setQuestion(String question) {
+    this.question = question;
+  }
+
+  public String getAnswer() {
+    return answer;
+  }
+
+  public void setAnswer(String answer) {
+    this.answer = answer;
+  }
+}

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/FaqServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/FaqServiceTest.java
@@ -21,15 +21,15 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 public class FaqServiceTest {
 
-  @Autowired
-  private FaqService faqService;
+  @Autowired private FaqService faqService;
 
-  @MockBean
-  private FaqRepository faqRepository;
+  @MockBean private FaqRepository faqRepository;
 
   @Test
   void testGetAllStudentFaqs() {
-    Faq faq1 = new Faq(1, "What is OUR?", "OUR stands for Office of Undergraduate Research.", FaqType.STUDENT);
+    Faq faq1 =
+        new Faq(
+            1, "What is OUR?", "OUR stands for Office of Undergraduate Research.", FaqType.STUDENT);
     Faq faq2 = new Faq(2, "How do I apply?", "You can apply via the portal.", FaqType.STUDENT);
 
     List<Faq> expectedFaqs = Arrays.asList(faq1, faq2);
@@ -61,5 +61,20 @@ public class FaqServiceTest {
     assertEquals(faq1, result.getFirst());
 
     verify(faqRepository, times(1)).findAllByFaqType(FaqType.FACULTY);
+  }
+
+  @Test
+  void testSaveEmailNotification() {
+    Faq faq = new Faq(1, "test question", "test answer", FaqType.STUDENT);
+
+    when(faqRepository.save(faq)).thenReturn(faq);
+
+    Faq savedFaq = faqService.saveFaq(faq);
+
+    assertNotNull(savedFaq);
+    assertEquals(1, savedFaq.getId());
+    assertEquals("test question", savedFaq.getQuestion());
+    assertEquals("test answer", savedFaq.getAnswer());
+    assertEquals(FaqType.STUDENT, savedFaq.getFaqType());
   }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1884,7 +1884,6 @@ void editDepartment_returnsExpectedResult() throws Exception {
   @Test
   @WithMockUser
   void createFaq_returnsExpectedResult() throws Exception {
-    // Arrange
     Faq faq = new Faq(1, "Test question", "Test answer", FaqType.STUDENT);
     when(faqService.saveFaq(any(Faq.class))).thenReturn(faq);
 

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1885,4 +1885,31 @@ void editDepartment_returnsExpectedResult() throws Exception {
         .andExpect(jsonPath("$[0].question").value("How do I approve accounts?"))
         .andExpect(jsonPath("$[0].answer").value("Via the admin panel"));
   }
+
+  @Test
+  @WithMockUser
+  void createFaq_returnsExpectedResult() throws Exception {
+    // Arrange
+    Faq faq = new Faq(1, "Test question", "Test answer", FaqType.STUDENT);
+    when(faqService.saveFaq(any(Faq.class))).thenReturn(faq);
+
+    FaqRequestDTO requestDTO = new FaqRequestDTO();
+    requestDTO.setId(1); // This will be ignored by the controller.
+    requestDTO.setQuestion("Test question");
+    requestDTO.setAnswer("Test answer");
+    requestDTO.setType(FaqType.STUDENT);
+
+    String requestJson = objectMapper.writeValueAsString(requestDTO);
+
+    mockMvc.perform(post("/faq")
+            .contentType("application/json")
+            .content(requestJson))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.question").value("Test question"))
+        .andExpect(jsonPath("$.answer").value("Test answer"))
+        .andExpect(jsonPath("$.type").value("STUDENT"));
+
+    verify(faqService, times(1)).saveFaq(any(Faq.class));
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New feature

**Summary:** Added `POST` mapping at endpoint `/faq` to support creating new FAQs.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added new `FaqRequestDTO` that will be used for `POST`/`PUT`/`DELETE` requests. Some fields in this DTO will be ignored depending on the request, e.g. in this PR since we're creating a new Faq, we'll ignore the `id` field.
- Added additional method in the Jpa service to support the needed operations.

## End-to-End Testing Instructions

1. Make sure the frontend app, the backend app, and the mysql database are running
2. Send `POST` request to endpoint `http://localhost:8080/faq` with valid data in the request body, and verify that the responses are as expected and includes the data of the new Faq.
