### PR TITLE
bug fix: login button navigates to posts page if the user is already logged in

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect } from 'react'
-import { BACKEND_URL } from './resources/constants'
+import { BACKEND_URL, FRONTEND_URL } from './resources/constants'
 import { Routes, Route } from 'react-router-dom'
 import { Box, CircularProgress } from '@mui/material'
 import RequireAuth from './components/authentication/RequireAuth'
@@ -36,7 +36,7 @@ import FAQs from './components/FAQs.js'
 import SharedLayout from './components/navigation/SharedLayout.js'
 
 function App () {
-  const [isAuthenticated, setisAuthenticated] = useState(false)
+  const [isAuthenticated, setisAuthenticated] = useState(true)
   const [isStudent, setIsStudent] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
   const [isFaculty, setIsFaculty] = useState(false)
@@ -85,7 +85,11 @@ function App () {
 
   // Redirect to the backend for login
   const handleLogin = () => {
-    window.location.href = `${BACKEND_URL}`
+    if (isAuthenticated) {
+      window.location.href = `${FRONTEND_URL}/posts`
+    } else {
+      window.location.href = `${BACKEND_URL}`
+    }
   }
 
   // Calls the backend to logout

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,7 +36,7 @@ import FAQs from './components/FAQs.js'
 import SharedLayout from './components/navigation/SharedLayout.js'
 
 function App () {
-  const [isAuthenticated, setisAuthenticated] = useState(true)
+  const [isAuthenticated, setisAuthenticated] = useState(false)
   const [isStudent, setIsStudent] = useState(false)
   const [isAdmin, setIsAdmin] = useState(false)
   const [isFaculty, setIsFaculty] = useState(false)

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import App from '../App'
 import { MemoryRouter } from 'react-router-dom'
-import { BACKEND_URL } from '../resources/constants'
+import { BACKEND_URL, FRONTEND_URL } from '../resources/constants'
 
 global.fetch = jest.fn()
 
@@ -26,7 +26,7 @@ describe('App', () => {
     })
   })
 
-  test('calls handleLogin and redirects', async () => {
+  test('calls handleLogin and redirects to login with backend if not logged in yet', async () => {
     render(
       <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <App />
@@ -38,6 +38,29 @@ describe('App', () => {
 
     // Check if window.location.href was updated
     await waitFor(() => expect(window.location.href).toBe(BACKEND_URL))
+  })
+
+  test('calls handleLogin and redirects to /posts if logged in', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        isAuthenticated: 'true',
+        isStudent: 'true',
+        isFaculty: 'false',
+        isAdmin: 'false'
+      })
+    })
+
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <App />
+      </MemoryRouter>
+    )
+
+    const loginButton = await screen.findByTestId('login-button')
+    fireEvent.click(loginButton)
+
+    await waitFor(() => expect(window.location.href).toBe(`${FRONTEND_URL}/posts`))
   })
 
   test('renders main layout if authenticated student', async () => {


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** The login button now sends the user to /posts if they have already logged in. Before, it would try to go back to login, but there would be an error if the user has already logged in on the backend. This bypasses trying to re-login on the backend. The user must logout before logging in again.

## End-to-End Testing Instructions
1. login
2. go back to the login/landing page
3. click login again
4. will go to /posts instead of "Whitelabel error page"