### PR TITLE
Implemented edit FAQ endpoint

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/FaqService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/FaqService.java
@@ -17,6 +17,10 @@ public class FaqService {
     this.faqRepository = faqRepository;
   }
 
+  public Faq getFaqById(int id) {
+    return faqRepository.findById(id).orElseThrow(() -> new RuntimeException("Faq not found with id: " + id));
+  }
+
   public List<Faq> getAllFaqsByType(FaqType faqType) {
     return faqRepository.findAllByFaqType(faqType);
   }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -1347,6 +1348,31 @@ public class GatewayController {
           savedFaq.getAnswer()
       );
       return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    } catch (Exception e) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  @PutMapping("/faq")
+  public ResponseEntity<FaqRequestDTO> editFaq(@RequestBody FaqRequestDTO requestBody) {
+    try {
+      if (requestBody.getQuestion().isEmpty() || requestBody.getAnswer().isEmpty()) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+      }
+      Faq existingFaq = faqService.getFaqById(requestBody.getId());
+      existingFaq.setQuestion(requestBody.getQuestion());
+      existingFaq.setAnswer(requestBody.getAnswer());
+
+      Faq editedFaq = faqService.saveFaq(existingFaq);
+      FaqRequestDTO faqRequestDTO = new FaqRequestDTO(
+          editedFaq.getId(),
+          editedFaq.getFaqType(),
+          editedFaq.getQuestion(),
+          editedFaq.getAnswer()
+      );
+
+      return ResponseEntity.status(HttpStatus.OK).body(faqRequestDTO);
+
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/FaqServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/FaqServiceTest.java
@@ -77,4 +77,34 @@ public class FaqServiceTest {
     assertEquals("test answer", savedFaq.getAnswer());
     assertEquals(FaqType.STUDENT, savedFaq.getFaqType());
   }
+
+  @Test
+  void testGetFaqById_success() {
+    Faq faq = new Faq(1, "Sample question", "Sample answer", FaqType.STUDENT);
+
+    when(faqRepository.findById(1)).thenReturn(java.util.Optional.of(faq));
+
+    Faq result = faqService.getFaqById(1);
+
+    assertNotNull(result);
+    assertEquals(1, result.getId());
+    assertEquals("Sample question", result.getQuestion());
+    assertEquals("Sample answer", result.getAnswer());
+    assertEquals(FaqType.STUDENT, result.getFaqType());
+
+    verify(faqRepository, times(1)).findById(1);
+  }
+
+  @Test
+  void testGetFaqById_notFound() {
+    when(faqRepository.findById(999)).thenReturn(java.util.Optional.empty());
+
+    RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+      faqService.getFaqById(999);
+    });
+
+    assertEquals("Faq not found with id: 999", exception.getMessage());
+
+    verify(faqRepository, times(1)).findById(999);
+  }
 }

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/GatewayControllerTest.java
@@ -1906,4 +1906,35 @@ void editDepartment_returnsExpectedResult() throws Exception {
 
     verify(faqService, times(1)).saveFaq(any(Faq.class));
   }
+
+  @Test
+  @WithMockUser
+  void editFaq_returnsExpectedResult() throws Exception {
+    Faq existingFaq = new Faq(1, "Old question", "Old answer", FaqType.STUDENT);
+    when(faqService.getFaqById(1)).thenReturn(existingFaq);
+
+    Faq editedFaq = new Faq(1, "Updated question", "Updated answer", FaqType.STUDENT);
+    when(faqService.saveFaq(any(Faq.class))).thenReturn(editedFaq);
+
+    FaqRequestDTO requestDTO = new FaqRequestDTO();
+    requestDTO.setId(1);
+    requestDTO.setQuestion("Updated question");
+    requestDTO.setAnswer("Updated answer");
+    requestDTO.setType(FaqType.STUDENT); // Will be ignored by the controller
+
+    String requestJson = objectMapper.writeValueAsString(requestDTO);
+
+    mockMvc.perform(put("/faq")
+            .contentType("application/json")
+            .content(requestJson))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.question").value("Updated question"))
+        .andExpect(jsonPath("$.answer").value("Updated answer"))
+        .andExpect(jsonPath("$.type").value("STUDENT"));
+
+    verify(faqService, times(1)).getFaqById(1);
+    verify(faqService, times(1)).saveFaq(any(Faq.class));
+  }
+
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature.

**Summary:** Added `PUT` mapping at endpoint `/faq` to support editing existing FAQs.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added additional method (`getFaqById(int id)`) in the Jpa service to support the needed operations.

## End-to-End Testing Instructions

1. Make sure the frontend app, the backend app, and the mysql database are running, and that there is valid faq data in the database.
2. Send `PUT` request to endpoint `http://localhost:8080/faq` with valid data in the request body, and verify that the response is as expected and that the FAQ was successfully edited.
