### PR TITLE
display message if admin tries to edit "Undeclared" or "Other"

### DIFF
--- a/frontend/src/__tests__/admin/add/handleAddDiscipline.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddDiscipline.test.js
@@ -71,6 +71,14 @@ describe('handleAddDiscipline', () => {
     expect(setError).toHaveBeenCalledWith('Bad request.')
   })
 
+  it('should set an error if fetch response is forbidden (403)', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 403 })
+
+    await handleAddDiscipline(newDisciplineName, setNewDisciplineName, setDisciplines, prepopulateMajorsWithDisciplines, setLoadingDisciplinesMajors, fetchDisciplines, setError)
+
+    expect(setError).toHaveBeenCalledWith('Discipline is permanent and cannot be duplicated.')
+  })
+
   it('should set an error if fetchDisciplines returns an empty array', async () => {
     fetch.mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue([]) })
     fetchDisciplines.mockResolvedValue([])

--- a/frontend/src/__tests__/admin/add/handleAddMajor.test.js
+++ b/frontend/src/__tests__/admin/add/handleAddMajor.test.js
@@ -83,6 +83,14 @@ describe('handleAddMajor', () => {
     expect(setError).toHaveBeenCalledWith('Bad request.')
   })
 
+  it('should set an error if fetch response is forbidden (403)', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 403 })
+
+    await handleAddMajor(newMajorName, setNewMajorName, newMajorDisciplines, setDisciplines, prepopulateMajorsWithDisciplines, setLoadingDisciplinesMajors, fetchDisciplines, setError)
+
+    expect(setError).toHaveBeenCalledWith("'Undeclared' is permanent and cannot be duplicated.")
+  })
+
   it('should set an error if fetchDisciplines returns an empty array', async () => {
     fetch.mockResolvedValue({ ok: true, json: jest.fn().mockResolvedValue([]) })
     fetchDisciplines.mockResolvedValue([])

--- a/frontend/src/__tests__/admin/delete/handleDeleteDiscipline.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteDiscipline.test.js
@@ -87,6 +87,14 @@ describe('handleDeleteDiscipline', () => {
     expect(setError).toHaveBeenCalledWith('Life Sciences cannot be deleted because it has connections to other projects. Please edit or remove those connections first. Remove connections, then try again.')
   })
 
+  it('should set error if discipline is not allowed to be deleted (403)', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 403 })
+
+    await handleDeleteDiscipline(1, setLoadingDisciplinesMajors, disciplines, setDisciplines, setDeletingIdDiscipline, setOpenDeleteDialog, setError, fetchDisciplines, prepopulateMajorsWithDisciplines)
+
+    expect(setError).toHaveBeenCalledWith('Discipline is permanent and cannot be deleted.')
+  })
+
   it('should set an error for unexpected errors', async () => {
     fetch.mockRejectedValue(new Error('Network error'))
 

--- a/frontend/src/__tests__/admin/delete/handleDeleteMajor.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteMajor.test.js
@@ -64,6 +64,14 @@ describe('handleDeleteMajor', () => {
     expect(setError).toHaveBeenCalledWith('Bad request.')
   })
 
+  it('should set error if the DELETE request is forbidden (403)', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 403 })
+
+    await handleDeleteMajor(1, setLoadingDisciplinesMajors, majors, setMajors, setDeletingIdMajor, setOpenDeleteDialog, setError)
+
+    expect(setError).toHaveBeenCalledWith("'Undeclared' is permanent and cannot be deleted.")
+  })
+
   it('should set error if major has connections (409)', async () => {
     fetch.mockResolvedValue({ ok: false, status: 409 })
 

--- a/frontend/src/__tests__/admin/edit/handleSaveDiscipline.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveDiscipline.test.js
@@ -55,6 +55,14 @@ describe('handleSaveDiscipline', () => {
     expect(setError).toHaveBeenCalledWith('Bad request.')
   })
 
+  it('should handle 403 error', async () => {
+    global.fetch.mockResolvedValue({ ok: false, status: 403 })
+
+    await handleSaveDiscipline(1, 'New Discipline', [], setDisciplines, setEditingIdDiscipline, setError)
+
+    expect(setError).toHaveBeenCalledWith('Discipline is permanent and cannot be editted.')
+  })
+
   it('should handle 409 conflict error', async () => {
     global.fetch.mockResolvedValue({ ok: false, status: 409 })
 

--- a/frontend/src/__tests__/admin/edit/handleSaveMajor.test.js
+++ b/frontend/src/__tests__/admin/edit/handleSaveMajor.test.js
@@ -82,6 +82,14 @@ describe('handleSaveMajor', () => {
     expect(setError).toHaveBeenCalledWith('New Name cannot be editted due to conflicts with other data. Remove connections, then try again.')
   })
 
+  it('should handle 403 for Undeclared major', async () => {
+    global.fetch.mockResolvedValue({ ok: false, status: 403 })
+
+    await handleSaveMajor(1, 'Undeclared', setEditingIdMajor, { 1: [{ name: 'Science' }] }, [], setMajors, setError)
+
+    expect(setError).toHaveBeenCalledWith("'Undeclared' is permanent and cannot be editted.")
+  })
+
   it('should handle unexpected errors', async () => {
     global.fetch.mockRejectedValue(new Error('500'))
 

--- a/frontend/src/utils/adminFetching.js
+++ b/frontend/src/utils/adminFetching.js
@@ -49,6 +49,8 @@ export const handleSaveMajor = async (id, editedNameMajor, setEditingIdMajor, se
       setError('Bad request.')
     } else if (error.message === '409') {
       setError(`${editedNameMajor} cannot be editted due to conflicts with other data. Remove connections, then try again.`)
+    } else if (error.message === '403') {
+      setError('\'Undeclared\' is permanent and cannot be editted.')
     } else {
       setError(`Unexpected error updating major: ${editedNameMajor}.`)
     }
@@ -92,6 +94,8 @@ export const handleAddMajor = async (newMajorName, setNewMajorName, newMajorDisc
   } catch (error) {
     if (error.message === '400') {
       setError('Bad request.')
+    } else if (error.message === '403') {
+      setError('\'Undeclared\' is permanent and cannot be duplicated.')
     } else if (error.message === '505') {
       setError('Major added, but there was an error loading updated disciplines and majors data.')
     } else {
@@ -132,6 +136,8 @@ export const handleDeleteMajor = async (id, setLoadingDisciplinesMajors, majors,
   } catch (error) {
     if (error.message === '400') {
       setError('Bad request.')
+    } else if (error.message === '403') {
+      setError('\'Undeclared\' is permanent and cannot be deleted.')
     } else if (error.message === '409') {
       setError(`${major.name} cannot be deleted because it has connections to other disciplines, projects, or students. Please edit or remove those connections first. Remove connections, then try again.`)
     } else {
@@ -172,6 +178,8 @@ export const handleSaveDiscipline = async (id, editedNameDiscipline, disciplines
   } catch (error) {
     if (error.message === '400') {
       setError('Bad request.')
+    } else if (error.message === '403') {
+      setError('Discipline is permanent and cannot be editted.')
     } else if (error.message === '409') {
       setError(`${editedNameDiscipline} cannot be editted due to conflicts with other data. Remove connections, then try again.`)
     } else {
@@ -212,6 +220,8 @@ export const handleAddDiscipline = async (newDisciplineName, setNewDisciplineNam
   } catch (error) {
     if (error.message === '400') {
       setError('Bad request.')
+    } else if (error.message === '403') {
+      setError('Discipline is permanent and cannot be duplicated.')
     } else if (error.message === '505') {
       setError('Discipline added, but there was an error loading updated disciplines and majors data.')
     } else {
@@ -262,6 +272,8 @@ export const handleDeleteDiscipline = async (id, setLoadingDisciplinesMajors, di
       setError('Bad request.')
     } else if (error.message === '409') {
       setError(`${disc.name} cannot be deleted because it has connections to other projects. Please edit or remove those connections first. Remove connections, then try again.`)
+    } else if (error.message === '403') {
+      setError('Discipline is permanent and cannot be deleted.')
     } else if (error.message === '505') {
       setError('Discipline deleted, but there was an error loading updated disciplines and majors data.')
     } else {


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** The frontend now renders an error message if the backend responds with 403 for trying to edit, add, or delete the "Undeclared" major or "Other" discipline. These are permanent and should not be manipulated by the admin. Now the frontend shows a message so they know why there was an error.

## UI/UX Implementation

New error message wording. Such as "'Undeclared' is permanent and cannot be deleted." We did not account for these messages before.

## Model Updates

No changes

### Data Models

No changes

### Object-Oriented Models

No changes

## End-to-End Testing Instructions
1. login as admin
2. go to manage-app-variables page by clicking button to go there
3. try to edit the 'undeclared' major. It won't work and a message will display.
4. try to add another 'undeclared' major. It won't work and a message will display. 
5. same for disciplines with 'other'