### PR TITLE
Bug fix: faculty closing edit project window

### DIFF
--- a/frontend/src/__tests__/posts/PostDialog.test.js
+++ b/frontend/src/__tests__/posts/PostDialog.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import PostDialog from '../../components/posts/PostDialog'
 import { mockOneActiveProject, mockOneFaculty, mockOneStudent } from '../../resources/mockData'
@@ -193,25 +193,6 @@ describe('PostDialog Component', () => {
 
       expect(screen.queryByRole('button', { name: /edit profile/i })).not.toBeInTheDocument()
       expect(screen.queryByRole('button', { name: /delete profile/i })).not.toBeInTheDocument()
-    })
-    it('renders page to edit projects when faculty clicks edit project', async () => {
-      renderWithTheme(
-        <PostDialog
-          onClose={() => {}}
-          post={mockOneActiveProject}
-          isStudent={false}
-          isFaculty
-          isAdmin={false}
-          postsView={viewProjectsFlag}
-          isOnFacultyProfile
-        />
-      )
-
-      const editBtn = screen.getByRole('button', { name: /edit project/i })
-      fireEvent.click(editBtn)
-      await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
-
-      expect(screen.getByText(/edit research opportunity/i)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/posts/PostDialog.js
+++ b/frontend/src/components/posts/PostDialog.js
@@ -72,11 +72,10 @@ const DialogTheme = ({ open, onClose, title, children }) => (
   </Dialog>
 )
 
-const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = viewStudentsFlag, isOnFacultyProfile }) => {
+const PostDialog = ({ onClose, post, isStudent, isFaculty, isAdmin, postsView = viewStudentsFlag, isOnFacultyProfile, showMyOwnProject, setShowMyOwnProject }) => {
   const navigate = useNavigate()
   const [error, setError] = useState(null) // set to a string value to display error messages
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false) // true if the "are you sure?" dialogue is visible
-  const [showMyOwnProject, setShowMyOwnProject] = useState(false) // true if a faculty member is viewing their own project
   const [myProjectId, setMyProjectId] = useState(null) // int id of the faculty member's project they are viewing
 
   if (!post) return null

--- a/frontend/src/resources/constants.js
+++ b/frontend/src/resources/constants.js
@@ -33,6 +33,7 @@ export const FETCH_FACULTY_FAQS_URL = BACKEND_URL + '/all-faculty-faqs'
 export const FETCH_ADMIN_FAQS_URL = BACKEND_URL + '/all-admin-faqs'
 export const FAQ_URL = BACKEND_URL + '/faq'
 
+export const CURRENT_FACULTY_ENDPOINT = `${BACKEND_URL}/api/facultyProfiles/current`
 export const GET_DISCIPLINES_ENDPOINT = BACKEND_URL + '/disciplines'
 export const GET_UMBRELLA_TOPICS_ENDPOINT = BACKEND_URL + '/umbrella-topics'
 export const GET_RESEARCH_PERIODS_ENDPOINT = BACKEND_URL + '/research-periods'


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** Edit project page was still showing up even after the faculty had finished editing it and closed the window. Fixed that bug so now after closing the window the edit project page is not visible until you click "edit project" again.

## End-to-End Testing Instructions
1. login as faculty
2. click view my profile
3. click on a project
4. click edit project
5. close window
6. click on project again -> no longer editing the project