### PR TITLE
Removed admin nav icons

### DIFF
--- a/frontend/src/__tests__/navigation/SharedLayout.test.js
+++ b/frontend/src/__tests__/navigation/SharedLayout.test.js
@@ -31,24 +31,6 @@ describe('SharedLayout', () => {
     // fetch.mockImplementation((url) => mockFetch(url, fetchHandlers))
   })
 
-  test('clicking icon navigates to /disciplines-and-majors', async () => {
-    renderWithTheme(<SharedLayout isAdmin />)
-
-    const button = screen.getByTestId('manage-app-variables-icon')
-    fireEvent.click(button)
-
-    expect(mockNavigate).toHaveBeenCalledWith('/disciplines-and-majors')
-  })
-
-  test('clicking icon navigates to /email-notifications', async () => {
-    renderWithTheme(<SharedLayout isAdmin />)
-
-    const button = screen.getByTestId('manage-email-notifications-icon')
-    fireEvent.click(button)
-
-    expect(mockNavigate).toHaveBeenCalledWith('/email-notifications')
-  })
-
   test('renders the ViewProfile component', async () => {
     renderWithTheme(<SharedLayout isAdmin handleLogout={handleLogout} />)
     const profilebtn = screen.getByText(/admin/i)

--- a/frontend/src/__tests__/navigation/SharedLayout.test.js
+++ b/frontend/src/__tests__/navigation/SharedLayout.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import SharedLayout from '../../components/navigation/SharedLayout'

--- a/frontend/src/components/navigation/SharedLayout.js
+++ b/frontend/src/components/navigation/SharedLayout.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import {
-  AppBar, Toolbar, Box, IconButton, Tooltip, CssBaseline,
+  AppBar, Toolbar, Box, IconButton, CssBaseline,
   BottomNavigation, BottomNavigationAction
 } from '@mui/material'
 import HomeIcon from '@mui/icons-material/Home'
@@ -8,7 +8,7 @@ import HelpCenterIcon from '@mui/icons-material/HelpCenter'
 import MenuIcon from '@mui/icons-material/Menu'
 import ScheduleSendIcon from '@mui/icons-material/ScheduleSend'
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'
-import { useNavigate, Link } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import TitleButton from './TitleButton'
 import SearchBar from '../filtering/SearchBar'
 import ViewProfile from '../profiles/ViewProfile'
@@ -21,7 +21,6 @@ const drawerWidth = 250
 const iconColor = '#0189ce'
 
 const SharedLayout = ({ isStudent = false, isFaculty = false, isAdmin = false, handleLogout, showingPosts = false, children }) => {
-  const navigate = useNavigate()
   const [open, setOpen] = useState(true) // by default should be open
 
   const toggleDrawer = () => {
@@ -73,20 +72,6 @@ const SharedLayout = ({ isStudent = false, isFaculty = false, isAdmin = false, h
 
           {/* Right Side: Admin Icons & ViewProfile */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            {isAdmin && (
-              <>
-                <Tooltip title='Manage App Variables' arrow data-testid='manage-app-variables-icon'>
-                  <IconButton onClick={() => navigate('/disciplines-and-majors')}>
-                    <AdminPanelSettingsIcon sx={{ color: iconColor }} />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title='Manage Email Notifications' arrow data-testid='manage-email-notifications-icon'>
-                  <IconButton onClick={() => navigate('/email-notifications')}>
-                    <ScheduleSendIcon sx={{ color: iconColor }} />
-                  </IconButton>
-                </Tooltip>
-              </>
-            )}
             <ViewProfile isStudent={isStudent} isFaculty={isFaculty} isAdmin={isAdmin} handleLogout={handleLogout} />
           </Box>
         </Toolbar>


### PR DESCRIPTION
# Overview

**Type of Change:** Other

**Summary:** Client said they don't need the extra icons for admin navigation on the top bar. Can navigate there with other buttons that already exist.

## End-to-End Testing Instructions
1. login as admin
2. see that there are no icon buttons on top right