### PR TITLE
Frontend display total number of results as text

### DIFF
--- a/frontend/src/components/posts/MainAccordion.js
+++ b/frontend/src/components/posts/MainAccordion.js
@@ -91,8 +91,11 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography sx={{ fontWeight: 'bold' }}>
+            <Typography sx={{ fontWeight: 'bold', mr: 1 }}>
               {discipline.name}
+            </Typography>
+            <Typography sx={{ color: 'gray' }}>
+              ({discipline.majors.reduce((sum, major) => sum + major.posts.length, 0)})
             </Typography>
           </Box>
         </AccordionSummary>

--- a/frontend/src/components/posts/MainAccordion.js
+++ b/frontend/src/components/posts/MainAccordion.js
@@ -159,7 +159,7 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography sx={{ fontWeight: 'bold', mr:1 }}>
+            <Typography sx={{ fontWeight: 'bold', mr: 1 }}>
               {department.name}
             </Typography>
             <Typography sx={{ color: 'gray' }}>

--- a/frontend/src/components/posts/MainAccordion.js
+++ b/frontend/src/components/posts/MainAccordion.js
@@ -159,8 +159,11 @@ function MainAccordion ({ postings, setSelectedPost, isStudent, isFaculty, isAdm
           }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography sx={{ fontWeight: 'bold' }}>
+            <Typography sx={{ fontWeight: 'bold', mr:1 }}>
               {department.name}
+            </Typography>
+            <Typography sx={{ color: 'gray' }}>
+              ({department.faculty.length})
             </Typography>
           </Box>
         </AccordionSummary>

--- a/frontend/src/components/posts/PostsLayout.js
+++ b/frontend/src/components/posts/PostsLayout.js
@@ -6,13 +6,12 @@
  */
 import React, { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Box, CircularProgress, Divider, Button } from '@mui/material'
+import { Box, CircularProgress, Divider, Button, Typography } from '@mui/material'
 import MainAccordion from './MainAccordion'
 import PostDialog from './PostDialog'
 import PropTypes from 'prop-types'
 import ViewButton from '../filtering/ViewButton'
-import { GET_STUDENTS_URL, GET_PROJECTS_URL, GET_FACULTY_URL, viewStudentsFlag, viewProjectsFlag, viewFacultyFlag, CUSTOM_BG_COLOR } from '../../resources/constants'
-// import { mockStudents, mockResearchOps, getAllFacultyExpectedResponse } from '../resources/mockData'
+import { GET_STUDENTS_URL, GET_PROJECTS_URL, GET_FACULTY_URL, viewStudentsFlag, viewProjectsFlag, viewFacultyFlag, CUSTOM_BG_COLOR, CUSTOM_BLUE_COLOR } from '../../resources/constants'
 
 function PostsLayout ({ isStudent, isFaculty, isAdmin }) {
   const navigate = useNavigate()
@@ -93,13 +92,13 @@ function PostsLayout ({ isStudent, isFaculty, isAdmin }) {
       <Box sx={{ display: 'flex', gap: '10px', marginBottom: '20px' }}>
 
         <Button
-          variant='outlined' sx={{ borderRadius: '20px', padding: '10px 20px' }}
+          variant='outlined' sx={{ borderRadius: '20px', padding: '10px 20px', color: '#0189ce' }}
           onClick={() => navigate('/disciplines-and-majors')} data-testid='manage-vars-btn'
         >Manage App Variables
         </Button>
 
         <Button
-          variant='outlined' sx={{ borderRadius: '20px', padding: '10px 20px' }}
+          variant='outlined' sx={{ borderRadius: '20px', padding: '10px 20px', color: '#0189ce' }}
           onClick={() => navigate('/email-notifications')} data-testid='manage-emails-btn'
         >Manage Email Notifications
         </Button>
@@ -168,6 +167,11 @@ function PostsLayout ({ isStudent, isFaculty, isAdmin }) {
               )
             : (
               <>
+
+                <Typography variant='subtitle2' sx={{ p: 2 }}>
+                  {postings.length} results
+                </Typography>
+
                 <MainAccordion
                   sx={{
                     maxHeight: { xs: '400px', md: '600px' },

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -242,23 +242,7 @@ export const mockResearchOps = [
       {
         id: 102,
         name: 'Electrical Engineering',
-        posts: [
-          {
-            id: 2001,
-            name: 'Post C',
-            description: 'this is a description for post C',
-            desiredQualifications: 'made of tin',
-            umbrellaTopics: ['Umbrella Topic test'],
-            researchPeriods: ['Fall 2025', 'Spring 2025'],
-            isActive: false,
-            majors: ['Electrical Engineering'],
-            faculty: {
-              firstName: 'Dr.',
-              lastName: 'Semiconductor',
-              email: 'semi@sandiego.edu'
-            }
-          }
-        ]
+        posts: []
       }
     ]
   },


### PR DESCRIPTION
# Overview

**Type of Change:** Styling

**Summary:** Client requested that we also show number of results for each discipline and as a sum total. Now on posts page:
1. number appears next to discipline name. For example: 'Life Sciences (3)'
2. total appears above dropdowns. For example '10 results'

## UI/UX Implementation
There is no Figma because client requested this after. These changes apply to the /posts page.

## End-to-End Testing Instructions
1. login
3. see number of results