### PR TITLE
Fixed discipline with no majors bug

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/util/ProjectHierarchyConverter.java
@@ -45,6 +45,10 @@ public final class ProjectHierarchyConverter {
     DisciplineDTO dto = new DisciplineDTO();
     dto.setId(proto.getDiscipline().getDisciplineId());
     dto.setName(proto.getDiscipline().getDisciplineName());
+    if (proto.getMajorsList().isEmpty()) {
+      dto.setMajors(new ArrayList<>());
+      return dto;
+    }
     if (proto.getMajorsList().getFirst().hasProjectCollection()) { // Has Project collection
       dto.setMajors(
           proto.getMajorsList().stream()

--- a/backend/src/test/java/COMP_49X_our_search/backend/gateway/ProjectHierarchyConverterTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/gateway/ProjectHierarchyConverterTest.java
@@ -73,4 +73,25 @@ public class ProjectHierarchyConverterTest {
     assertTrue(projectDTO.getIsActive());
     assertEquals(List.of("Computer Science"), projectDTO.getMajors());
   }
+
+  @Test
+  public void testProtoDisciplineWithMajorsToDto_withEmptyMajorsList() {
+    DisciplineWithMajors disciplineProto =
+        DisciplineWithMajors.newBuilder()
+            .setDiscipline(
+                DisciplineProto.newBuilder()
+                    .setDisciplineId(202)
+                    .setDisciplineName("New Discipline")
+                    .build())
+            .build();
+
+    DisciplineDTO disciplineDTO =
+        ProjectHierarchyConverter.protoDisciplineWithMajorsToDto(disciplineProto);
+
+    assertNotNull(disciplineDTO);
+    assertEquals(202, disciplineDTO.getId());
+    assertEquals("New Discipline", disciplineDTO.getName());
+    assertNotNull(disciplineDTO.getMajors(), "Majors list should not be null");
+    assertTrue(disciplineDTO.getMajors().isEmpty(), "Majors list should be empty");
+  }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** Fixed bug where disciplines with no majors would throw an error when calling the `/all-projects` or `/all-students` endpoint.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

1) Make sure the frontend app, backend app, and mysql database are running, and that there is valid data in the database, specifically majors and disciplines, and that at least 1 discipline is 'empty', i.e. no major is associated to it.
2) Send `GET` request at endpoints `/all-projects' or `/all-students` and make sure that the response is as expected and without errors.
