### PR TITLE
Fixed deleting discipline bug

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/DisciplineService.java
@@ -78,7 +78,21 @@ public class DisciplineService {
     // Since we have a relationship tables, when we delete a discipline we have
     // to remove these relationships first before attempting to delete the
     // discipline.
-    discipline.getMajors().forEach(major -> major.getDisciplines().remove(discipline));
+
+    Discipline otherDiscipline = getOtherDiscipline();
+    discipline
+        .getMajors()
+        .forEach(
+            major -> {
+              major.getDisciplines().remove(discipline);
+              // If the discipline that was removed was the only discipline a
+              // major belonged to, the major should be moved to the "Other"
+              // discipline, otherwise it would stay unassociated.
+              if (major.getDisciplines().isEmpty()) {
+                major.getDisciplines().add(otherDiscipline);
+                otherDiscipline.getMajors().add(major);
+              }
+            });
     discipline.getStudents().forEach(student -> student.getDisciplines().remove(discipline));
 
     discipline.getMajors().clear();

--- a/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
+++ b/backend/src/test/java/COMP_49X_our_search/backend/database/DisciplineServiceTest.java
@@ -219,7 +219,6 @@ public class DisciplineServiceTest {
 
     verify(majorRepository, never()).save(any(Major.class));
     verify(studentRepository, never()).save(any(Student.class));
-    verify(disciplineRepository, never()).save(any(Discipline.class));
   }
 
   @Test


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** Fixed bug where if we delete a discipline and there is a major that belonged to only that discipline, the major would stay unassociated, instead of being reassigned to the "Other" discipline.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

1. Make sure you have valid major and discipline data in the database, and at least one major that belongs to only 1 discipline. 
2. Delete the discipline and verify that the major was moved to "Other"
