### PR TITLE
feat: apply button sends search now

### DIFF
--- a/frontend/src/__tests__/filtering/SearchBar.test.js
+++ b/frontend/src/__tests__/filtering/SearchBar.test.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, useNavigate } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import SearchBar from '../../components/filtering/SearchBar'
+import { viewProjectsFlag } from '../../resources/constants'
 
 const renderWithTheme = (ui) => {
   const theme = createTheme()
@@ -25,51 +26,33 @@ jest.mock('react-router-dom', () => ({
 global.fetch = jest.fn()
 
 describe('Searchbar', () => {
-  const mockNavigate = jest.fn()
+  const handleApply = jest.fn()
+  const setSearchQuery = jest.fn()
+
+  const defaultProps = {
+    handleApply,
+    searchQuery: '',
+    setSearchQuery,
+    postsView: viewProjectsFlag
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
-    useNavigate.mockReturnValue(mockNavigate)
   })
 
-  test('renders umbrella topics, majors, and research periods filter options for projects view', () => {
-    renderWithTheme(<SearchBar />)
-  })
-
-  test('updates the input value as the user types', async () => {
-    renderWithTheme(<SearchBar />)
+  test('calls handleApply when Enter is pressed', async () => {
+    renderWithTheme(<SearchBar {...defaultProps} />)
     const input = screen.getByRole('textbox', { name: /search/i })
-    await userEvent.type(input, 'hello world')
-    expect(input).toHaveValue('hello world')
+    await userEvent.type(input, 'test{enter}')
+    expect(handleApply).toHaveBeenCalledTimes(1)
   })
 
-  test('navigates with ?search=… when Enter is pressed', async () => {
-    renderWithTheme(<SearchBar />)
+  test('calls handleApply when clicking the search icon', async () => {
+    const { container } = renderWithTheme(<SearchBar {...defaultProps} />)
     const input = screen.getByRole('textbox', { name: /search/i })
-    await userEvent.type(input, 'foo bar{enter}')
-    expect(mockNavigate).toHaveBeenCalledWith('?search=foo+bar', { replace: true })
-  })
-
-  test('removes the search param when input is cleared and Enter is pressed', async () => {
-    renderWithTheme(<SearchBar />)
-    const input = screen.getByRole('textbox', { name: /search/i })
-
-    await userEvent.type(input, 'abc{enter}')
-    expect(mockNavigate).toHaveBeenLastCalledWith('?search=abc', { replace: true })
-
-    await userEvent.clear(input)
-    fireEvent.keyPress(input, { key: 'Enter', code: 'Enter', charCode: 13 })
-    expect(mockNavigate).toHaveBeenLastCalledWith('?', { replace: true })
-  })
-
-  test('navigates when clicking the search icon', async () => {
-    const { container } = renderWithTheme(<SearchBar />)
-    const input = screen.getByRole('textbox', { name: /search/i })
-
     await userEvent.type(input, 'icon test')
     const svg = container.querySelector('svg')
     fireEvent.click(svg)
-
-    expect(mockNavigate).toHaveBeenCalledWith('?search=icon+test', { replace: true })
+    expect(handleApply).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/components/filtering/SearchBar.js
+++ b/frontend/src/components/filtering/SearchBar.js
@@ -5,44 +5,37 @@
 * @author Rayan Pal <rpal@sandiego.edu>
 */
 
-import React, { useState } from 'react'
+import React from 'react'
 import { Box, TextField, InputAdornment } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
-import { useNavigate } from 'react-router-dom'
+import { viewFacultyFlag, viewProjectsFlag, viewStudentsFlag } from '../../resources/constants'
 
-function SearchBar () {
-  const [searchQuery, setSearchQuery] = useState('')
-  const navigate = useNavigate()
-
-  const handleSearch = () => {
-    const next = new URLSearchParams(window.location.search)
-
-    if (searchQuery) {
-      next.set('search', searchQuery)
-    } else {
-      next.delete('search')
-    }
-
-    navigate(`?${next.toString()}`, { replace: true })
+function SearchBar ({ handleApply, searchQuery, setSearchQuery, postsView }) {
+  let label = 'Search'
+  if (postsView === viewStudentsFlag) {
+    label = 'Search for name or interest reason'
+  } else if (postsView === viewProjectsFlag) {
+    label = 'Search for title, description, desired qualification, faculty name'
+  } else if (postsView === viewFacultyFlag) {
+    label = 'Search for name'
   }
-
   return (
     <Box sx={{ ml: 1, mr: 3 }}>
       <TextField
         fullWidth
-        label='Search'
+        label={label}
         id='searchField'
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
         onKeyPress={(e) => {
           if (e.key === 'Enter') {
-            handleSearch()
+            handleApply()
           }
         }}
         InputProps={{
           endAdornment: (
             <InputAdornment position='end'>
-              <SearchIcon onClick={handleSearch} style={{ cursor: 'pointer' }} />
+              <SearchIcon onClick={handleApply} style={{ cursor: 'pointer' }} />
             </InputAdornment>
           )
         }}

--- a/frontend/src/components/filtering/Sidebar.js
+++ b/frontend/src/components/filtering/Sidebar.js
@@ -20,7 +20,6 @@ import {
 } from '../../resources/constants'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import getDataFrom from '../../utils/getDataFrom'
-import { getMajorsExpectedResponse, getResearchPeriodsExpectedResponse, getUmbrellaTopicsExpectedResponse } from '../../resources/mockData'
 
 function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
   if (!postsView) postsView = viewProjectsFlag
@@ -34,13 +33,13 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
   const [searchQuery, setSearchQuery] = useState('')
 
   // filters for projects only
-  const [umbrellaTopics, setUmbrellaTopics] = useState(getUmbrellaTopicsExpectedResponse)
+  const [umbrellaTopics, setUmbrellaTopics] = useState([])
   const [selectedUmbrellaTopics, setSelectedUmbrellaTopics] = useState([]) // selected determines what is checked already
 
   // filters for both students and projects
-  const [researchPeriods, setResearchPeriods] = useState(getResearchPeriodsExpectedResponse)
+  const [researchPeriods, setResearchPeriods] = useState([])
   const [selectedResearchPeriods, setSelectedResearchPeriods] = useState([])
-  const [majors, setMajors] = useState(getMajorsExpectedResponse)
+  const [majors, setMajors] = useState([])
   const [selectedMajors, setSelectedMajors] = useState([])
 
   const TYPE_MAJORS = 'Majors'
@@ -93,7 +92,7 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
         setLoadingInitial(false)
       }
     }
-    // fetchData()
+    fetchData()
   }, [postsView, search])
 
   const handleCheckboxChange = (id, type) => {

--- a/frontend/src/components/filtering/Sidebar.js
+++ b/frontend/src/components/filtering/Sidebar.js
@@ -28,7 +28,7 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const [error, setError] = useState(null)
-  const [loadingInitial, setLoadingInitial] = useState(false)
+  const [loadingInitial, setLoadingInitial] = useState(true)
 
   const [searchQuery, setSearchQuery] = useState('')
 

--- a/frontend/src/components/filtering/Sidebar.js
+++ b/frontend/src/components/filtering/Sidebar.js
@@ -20,6 +20,7 @@ import {
 } from '../../resources/constants'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import getDataFrom from '../../utils/getDataFrom'
+import { getMajorsExpectedResponse, getResearchPeriodsExpectedResponse, getUmbrellaTopicsExpectedResponse } from '../../resources/mockData'
 
 function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
   if (!postsView) postsView = viewProjectsFlag
@@ -28,16 +29,18 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const [error, setError] = useState(null)
-  const [loadingInitial, setLoadingInitial] = useState(true)
+  const [loadingInitial, setLoadingInitial] = useState(false)
+
+  const [searchQuery, setSearchQuery] = useState('')
 
   // filters for projects only
-  const [umbrellaTopics, setUmbrellaTopics] = useState([])
+  const [umbrellaTopics, setUmbrellaTopics] = useState(getUmbrellaTopicsExpectedResponse)
   const [selectedUmbrellaTopics, setSelectedUmbrellaTopics] = useState([]) // selected determines what is checked already
 
   // filters for both students and projects
-  const [researchPeriods, setResearchPeriods] = useState([])
+  const [researchPeriods, setResearchPeriods] = useState(getResearchPeriodsExpectedResponse)
   const [selectedResearchPeriods, setSelectedResearchPeriods] = useState([])
-  const [majors, setMajors] = useState([])
+  const [majors, setMajors] = useState(getMajorsExpectedResponse)
   const [selectedMajors, setSelectedMajors] = useState([])
 
   const TYPE_MAJORS = 'Majors'
@@ -90,7 +93,7 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
         setLoadingInitial(false)
       }
     }
-    fetchData()
+    // fetchData()
   }, [postsView, search])
 
   const handleCheckboxChange = (id, type) => {
@@ -119,6 +122,12 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
     // clone existing params so we don't clobber unrelated ones
     const next = new URLSearchParams(searchParams)
 
+    if (searchQuery) {
+      next.set('search', searchQuery)
+    } else {
+      next.delete('search')
+    }
+
     if (selectedMajors.length) {
       next.set('majors', selectedMajors.join(','))
     } else {
@@ -144,12 +153,14 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
     setSelectedMajors([])
     setSelectedResearchPeriods([])
     setSelectedUmbrellaTopics([])
+    setSearchQuery('')
 
     // remove only the filter params, keep any others
     const next = new URLSearchParams(searchParams)
     next.delete('majors')
     next.delete('researchPeriods')
     next.delete('umbrellaTopics')
+    next.delete('search')
 
     navigate(`?${next.toString()}`, { replace: true })
   }
@@ -274,7 +285,7 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
       return (
         <Box sx={{ width: drawerWidth, CUSTOM_BG_COLOR, mt: 7 }} role='presentation'>
           {renderCloseButton()}
-          <SearchBar />
+          <SearchBar handleApply={handleApply} searchQuery={searchQuery} setSearchQuery={setSearchQuery} postsView={postsView} />
           <Typography variant='h6' sx={{ mt: 6, ml: 2 }}>
             Filter
           </Typography>
@@ -291,7 +302,7 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
       return (
         <Box sx={{ width: drawerWidth, CUSTOM_BG_COLOR, mt: 7 }} role='presentation'>
           {renderCloseButton()}
-          <SearchBar />
+          <SearchBar handleApply={handleApply} searchQuery={searchQuery} setSearchQuery={setSearchQuery} postsView={postsView} />
           <Typography variant='h6' sx={{ mt: 3, ml: 2, mb: 1 }}>
             Filter
           </Typography>
@@ -309,7 +320,7 @@ function Sidebar ({ drawerWidth, open, postsView, toggleDrawer }) {
       return (
         <Box sx={{ width: drawerWidth, CUSTOM_BG_COLOR, mt: 7 }} role='presentation'>
           {renderCloseButton()}
-          <SearchBar />
+          <SearchBar handleApply={handleApply} searchQuery={searchQuery} setSearchQuery={setSearchQuery} postsView={postsView} />
         </Box>
       )
     }

--- a/frontend/src/components/posts/PostsLayout.js
+++ b/frontend/src/components/posts/PostsLayout.js
@@ -25,6 +25,7 @@ function PostsLayout ({ isStudent, isFaculty, isAdmin, toggleDrawer, drawerOpen 
   const [searchParams] = useSearchParams()
   const [error, setError] = useState(null)
   const { search } = useLocation()
+  const [filteredMsg, setFilteredMsg] = useState('')
 
   const [showMyOwnProject, setShowMyOwnProject] = useState(false)
   const closeMyProjectPopup = () => {
@@ -126,6 +127,33 @@ function PostsLayout ({ isStudent, isFaculty, isAdmin, toggleDrawer, drawerOpen 
     currentParams.delete('postsView')
     const paramsForFilters = currentParams.toString()
 
+    let msgAboutFilters = ''
+
+    if (currentParams.has('researchPeriods')) {
+      msgAboutFilters += 'Filters applied: research period'
+    }
+    if (currentParams.has('majors')) {
+      msgAboutFilters += msgAboutFilters.length === 0
+        ? 'Filters applied: majors'
+        : ', majors'
+    }
+    if (currentParams.has('umbrellaTopics')) {
+      msgAboutFilters += msgAboutFilters.length === 0
+        ? 'Filters applied: umbrella topics'
+        : ', umbrella topics'
+    }
+    if (currentParams.has('search')) {
+      msgAboutFilters += msgAboutFilters.length === 0
+        ? 'Filters applied: search bar'
+        : ', search bar'
+    }
+
+    if (msgAboutFilters.length > 0) {
+      setFilteredMsg(msgAboutFilters)
+    } else {
+      setFilteredMsg('')
+    }
+
     // fetch the data to show
     const fetchData = async () => {
       // PostsLayout is the primary controller of postsView, which gets passed to child components.
@@ -162,25 +190,6 @@ function PostsLayout ({ isStudent, isFaculty, isAdmin, toggleDrawer, drawerOpen 
       )
     }
   }
-  // const renderAdminManageButtons = () => {
-  //   return (
-  //     <Box sx={{ display: 'flex', gap: '10px', marginBottom: '20px' }}>
-
-  //       <Button
-  //         variant='outlined' sx={{ borderRadius: '20px', padding: '10px 20px' }}
-  //         onClick={() => navigate('/disciplines-and-majors')} data-testid='manage-vars-btn'
-  //       >Manage App Variables
-  //       </Button>
-
-  //       <Button
-  //         variant='outlined' sx={{ borderRadius: '20px', padding: '10px 20px' }}
-  //         onClick={() => navigate('/email-notifications')} data-testid='manage-emails-btn'
-  //       >Manage Email Notifications
-  //       </Button>
-
-  //     </Box>
-  //   )
-  // }
   const renderAdminPostsViewButtons = () => {
     return (
       <Box sx={{ overflowX: 'auto', whiteSpace: 'nowrap', '&::-webkit-scrollbar': { display: 'none' } }}>
@@ -365,6 +374,9 @@ function PostsLayout ({ isStudent, isFaculty, isAdmin, toggleDrawer, drawerOpen 
             {renderShowFilterBtn()}
             <Typography sx={{ mt: 2, ml: 3, fontWeight: 'bold' }}>
               Results: {getTotalPostCount()} Posts
+            </Typography>
+            <Typography sx={{ mt: 1, ml: 3, fontWeight: 'bold', color: CUSTOM_BUTTON_COLOR }}>
+              {filteredMsg}
             </Typography>
             {loading
               ? (


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Made it so hitting Apply, enter on the search bar, or the search icon on the search bar will set all filters and search. Hitting reset will reset the search bar and all the filters. This is for making filtering consistent.

## UI/UX Implementation
none

## Model Updates
none

### Data Models
none

### Object-Oriented Models
none

## End-to-End Testing Instructions
1. login
2. enter search query. click apply or enter or the search icon. will send the search. 
3. enter search query, then click filters. click apply or enter or search icon. will send the search and the filters.
4. enter filters, then search query. click apply or enter or search icon. will send the search and the filters.
5. enter filters. apply. will send filters. enter search. apply. will send search with previous filters. 
6. enter search. apply. will send search. enter filters. apply. will send filters with previous search.
7. any other possible ordering of search and filter will work. 
8. hit reset will always reset everything.