### PR TITLE
Add support for creating an admin user via start script and environment variable

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
@@ -12,7 +12,9 @@ package COMP_49X_our_search.backend.database.services;
 import COMP_49X_our_search.backend.database.entities.User;
 import COMP_49X_our_search.backend.database.enums.UserRole;
 import COMP_49X_our_search.backend.database.repositories.UserRepository;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,9 +24,29 @@ public class UserService {
 
   private final UserRepository userRepository;
 
+  @Value("${ADMIN_EMAIL:}")
+  private String adminEmail;
+
   @Autowired
   public UserService(UserRepository userRepository) {
     this.userRepository = userRepository;
+  }
+
+  @PostConstruct
+  public void createFirstAdmin() {
+    if (adminEmail == null || adminEmail.isBlank()) {
+      System.out.println("ADMIN_EMAIL environment variable is  not set. Skipping admin creation.");
+      return;
+    }
+
+    if (!userExists(adminEmail)) {
+      User adminUser = new User(adminEmail, UserRole.ADMIN);
+      userRepository.save(adminUser);
+      System.out.println("Admin user created on startup with email: " + adminEmail);
+    } else {
+      System.out.printf(
+          "User with email %s already exists. Skipping admin creation.%n", adminEmail);
+    }
   }
 
   public UserRole getUserRoleByEmail(String email) {
@@ -49,12 +71,12 @@ public class UserService {
   public void deleteUserByEmail(String email) {
     if (!userExists(email)) {
       throw new RuntimeException(
-              String.format("Cannot delete user with email '%s'. User not found", email));
+          String.format("Cannot delete user with email '%s'. User not found", email));
     }
     userRepository.deleteByEmail(email);
   }
 
-  public List<User> getAllUsers (){
+  public List<User> getAllUsers() {
     return userRepository.findAll();
   }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,7 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/forum
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=root
+      - ADMIN_EMAIL=${ADMIN_EMAIL}
     depends_on:
       db:
         condition: service_healthy

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,7 @@
 
 usage() {
   echo "Usage: $0 --new_admin=<admin_email>"
+  echo "Creates a new admin user on startup by passing the email to the backend."
   exit 1
 }
 
@@ -25,6 +26,7 @@ fi
 
 export ADMIN_EMAIL="$ADMIN_EMAIL"
 
+echo "A new admin will be created with the email: $ADMIN_EMAIL"
 echo "Starting Docker Compose with ADMIN_EMAIL=$ADMIN_EMAIL"
 
 # Note: add --build if images need to be rebuilt, e.g. when changes are made,

--- a/start.sh
+++ b/start.sh
@@ -19,16 +19,14 @@ for arg in "$@"; do
   esac
 done
 
-if [ -z "$ADMIN_EMAIL" ]; then
-  echo "Error: --new_admin is required."
-  usage
+# Set environment variable ADMIN_EMAIL only if provided in the script argument
+if [ -n "$ADMIN_EMAIL" ]; then
+  export ADMIN_EMAIL="$ADMIN_EMAIL"
+  echo "A new admin will be created with the email: $ADMIN_EMAIL"
+else
+  echo "No admin email provided. Skipping admin creation."
 fi
 
-export ADMIN_EMAIL="$ADMIN_EMAIL"
-
-echo "A new admin will be created with the email: $ADMIN_EMAIL"
-echo "Starting Docker Compose with ADMIN_EMAIL=$ADMIN_EMAIL"
-
-# Note: add --build if images need to be rebuilt, e.g. when changes are made,
-# or run docker compose up --build beforehand.
+echo "Starting Docker Compose..."
+# Note: add --build if images need to be rebuilt, or run 'docker compose up --build' outside the script beforehand.
 docker compose up

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+usage() {
+  echo "Usage: $0 --first_admin_email=<admin_email>"
+  exit 1
+}
+
+for arg in "$@"; do
+  case $arg in
+    --first_admin_email=*)
+    ADMIN_EMAIL="${arg#*=}"
+    shift
+    ;;
+  *)
+    echo "Invalid argument: $arg"
+    usage
+    ;;
+  esac
+done
+
+if [ -z "$ADMIN_EMAIL" ]; then
+  echo "Error: --first_admin_email is required."
+  usage
+fi
+
+export ADMIN_EMAIL="$ADMIN_EMAIL"
+
+echo "Starting Docker Compose with ADMIN_EMAIL=$ADMIN_EMAIL"
+
+# Note: add --build if images need to be rebuilt, e.g. when changes are made,
+# or run docker compose up --build beforehand.
+docker compose up

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 --first_admin_email=<admin_email>"
+  echo "Usage: $0 --new_admin=<admin_email>"
   exit 1
 }
 
 for arg in "$@"; do
   case $arg in
-    --first_admin_email=*)
+    --new_admin=*)
     ADMIN_EMAIL="${arg#*=}"
     shift
     ;;
@@ -19,7 +19,7 @@ for arg in "$@"; do
 done
 
 if [ -z "$ADMIN_EMAIL" ]; then
-  echo "Error: --first_admin_email is required."
+  echo "Error: --new_admin is required."
   usage
 fi
 


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Added support for creating an admin user when initializing the app for the first time.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

- Added `@PostConstruct` method in the `UserService` to create an admin user upon initialization.

## End-to-End Testing Instructions

- Either:
  - Set environment variable `ADMIN_EMAIL` in `compose.yaml` and run command `./start.sh`, or
  - Run command `./start.sh --new_admin=<admin_email>`.
- Verify that the admin user was created
