### PR TITLE
Support for configuring Google credentials via start script

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -33,6 +33,8 @@ services:
       - SPRING_DATASOURCE_USERNAME=root
       - SPRING_DATASOURCE_PASSWORD=root
       - ADMIN_EMAIL=${ADMIN_EMAIL}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
     depends_on:
       db:
         condition: service_healthy

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 --new_admin=<admin_email>"
-  echo "Creates a new admin user on startup by passing the email to the backend."
+  echo "Usage: $0 --new_admin=<admin_email> --google_id=<client_id> --google_secret=<client_secret>"
+  echo "Creates a new admin user and starts Docker Compose with required Google OAuth credentials."
   exit 1
 }
 
@@ -12,12 +12,26 @@ for arg in "$@"; do
     ADMIN_EMAIL="${arg#*=}"
     shift
     ;;
-  *)
+    --google_id=*)
+    GOOGLE_CLIENT_ID="${arg#*=}"
+    shift
+    ;;
+    --google_secret=*)
+    GOOGLE_CLIENT_SECRET="${arg#*=}"
+    shift
+    ;;
+    *)
     echo "Invalid argument: $arg"
     usage
     ;;
   esac
 done
+
+# Validate required args
+if [ -z "$GOOGLE_CLIENT_ID" ] || [ -z "$GOOGLE_CLIENT_SECRET" ]; then
+  echo "Error: Both --google_id and --google_secret must be provided."
+  usage
+fi
 
 # Set environment variable ADMIN_EMAIL only if provided in the script argument
 if [ -n "$ADMIN_EMAIL" ]; then
@@ -27,6 +41,9 @@ else
   echo "No admin email provided. Skipping admin creation."
 fi
 
+export GOOGLE_CLIENT_ID="$GOOGLE_CLIENT_ID"
+export GOOGLE_CLIENT_SECRET="$GOOGLE_CLIENT_SECRET"
+
 echo "Starting Docker Compose..."
 # Note: add --build if images need to be rebuilt, or run 'docker compose up --build' outside the script beforehand.
-docker compose up
+docker compose up --build


### PR DESCRIPTION
# Overview

**Type of Change:** New Feature

**Summary:** Made the Google credentials configurable **and required** whenever the app starts via the start script. This way, users can configure their own Google client. 

## End-to-End Testing Instructions
1. Run command `./start.sh --google_id=<xyz> --google_secret=<xyz>`.
2. Click login. Verify that it worked if logging in redirects you to Google.