### PR TITLE
Bug: admin delete email

### DIFF
--- a/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/UserRepository.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/repositories/UserRepository.java
@@ -16,5 +16,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository
     extends JpaRepository<User, Integer> {
   Optional<User> findByEmail(String email);
+  Optional<User> findById(int id);
   void deleteByEmail(String email);
+  void deleteById(int id);
 }

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
@@ -59,6 +59,9 @@ public class UserService {
   public boolean userExists(String email) {
     return userRepository.findByEmail(email).isPresent();
   }
+  public boolean userExists(int id) {
+    return userRepository.findById(id).isPresent();
+  }
 
   public User createUser(String email, UserRole role) {
     if (userExists(email)) {
@@ -74,6 +77,14 @@ public class UserService {
           String.format("Cannot delete user with email '%s'. User not found", email));
     }
     userRepository.deleteByEmail(email);
+  }
+
+  public void deleteUserById(int id) {
+    if (!userExists(id)) {
+      throw new RuntimeException(
+          String.format("Cannot delete user with email '%s'. User not found. ID = ", id));
+    }
+    userRepository.deleteById(id);
   }
 
   public List<User> getAllUsers() {

--- a/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/database/services/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
   public void deleteUserById(int id) {
     if (!userExists(id)) {
       throw new RuntimeException(
-          String.format("Cannot delete user with email '%s'. User not found. ID = ", id));
+          String.format("Cannot delete user with ID = %d", id));
     }
     userRepository.deleteById(id);
   }

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -1451,6 +1451,10 @@ public class GatewayController {
       return ResponseEntity.status(HttpStatus.CONFLICT).body("Cannot delete email of user who is currently logged in.");
     }
 
+    if (userService.getUserRoleByEmail(dto.getEmail()) != UserRole.ADMIN) { // This should never happen, but the check is here just in case
+      return ResponseEntity.status(HttpStatus.CONFLICT).body("Cannot delete email of user who already has a profile and is not an admin.");
+    }
+
     try {
       userService.deleteUserById(dto.getId());
       return ResponseEntity.ok().build();

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/GatewayController.java
@@ -1423,7 +1423,7 @@ public class GatewayController {
   public ResponseEntity<List<AdminEmailDTO>> getAdminEmails() {
     List<AdminEmailDTO> admins = userService.getAllUsers().stream()
       .filter(u -> u.getUserRole() == UserRole.ADMIN)
-      .map(u -> new AdminEmailDTO(u.getEmail()))
+      .map(u -> new AdminEmailDTO(u.getEmail(), u.getId()))
       .toList();
     return ResponseEntity.ok(admins);
   }
@@ -1443,17 +1443,20 @@ public class GatewayController {
   }
 
   @DeleteMapping("/admin-emails")
-  public ResponseEntity<Void> deleteAdminEmail(@RequestBody AdminEmailDTO dto) {
-    try {
-      userService.deleteUserByEmail(dto.getEmail());
-      return ResponseEntity.ok().build();
-    } catch (RuntimeException e) {
-      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+  public ResponseEntity<String> deleteAdminEmail(@RequestBody AdminEmailDTO dto) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+    String currentUserEmail = oAuthChecker.getAuthUserEmail(authentication);
+    if (currentUserEmail.equals(dto.getEmail())) {
+      return ResponseEntity.status(HttpStatus.CONFLICT).body("Cannot delete email of user who is currently logged in.");
+    }
+
+    try {
+      userService.deleteUserById(dto.getId());
+      return ResponseEntity.ok().build();
     } catch (Exception e) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
-    
   }
 
 

--- a/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/AdminEmailDTO.java
+++ b/backend/src/main/java/COMP_49X_our_search/backend/gateway/dto/AdminEmailDTO.java
@@ -1,12 +1,14 @@
 package COMP_49X_our_search.backend.gateway.dto;
 
 public class AdminEmailDTO {
-  private String email;
+  private String email; // required for POST
+  private int id; // required for DELETE
 
   public AdminEmailDTO() {}
 
-  public AdminEmailDTO(String email) {
+  public AdminEmailDTO(String email, int id) {
     this.email = email;
+    this.id = id;
   }
 
   public String getEmail() {
@@ -15,5 +17,13 @@ public class AdminEmailDTO {
 
   public void setEmail(String email) {
     this.email = email;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
   }
 }

--- a/frontend/src/__tests__/admin/delete/handleDeleteAdminEmail.test.js
+++ b/frontend/src/__tests__/admin/delete/handleDeleteAdminEmail.test.js
@@ -41,7 +41,7 @@ describe('handleDeleteEmail', () => {
       credentials: 'include',
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: 1 })
+      body: JSON.stringify({ id: 1, email: 'admin1@sandiego.edu' })
     })
   })
 

--- a/frontend/src/resources/mockData.js
+++ b/frontend/src/resources/mockData.js
@@ -736,6 +736,16 @@ export const getAllFacultyExpectedResponse = [
             researchPeriods: ['Spring 2025'],
             isActive: true,
             majors: ['Chemistry']
+          },
+          {
+            id: 10,
+            name: 'Test Inactive Project',
+            description: 'this is a description',
+            desiredQualifications: 'student in chem',
+            umbrellaTopics: ['Umbrella Topic Mock'],
+            researchPeriods: ['Spring 2025'],
+            isActive: false,
+            majors: ['Chemistry']
           }
         ]
       },

--- a/frontend/src/utils/adminFetching.js
+++ b/frontend/src/utils/adminFetching.js
@@ -702,7 +702,8 @@ export const handleDeleteEmail = async (id, setLoading, AdminEmails, setAdminEma
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        id
+        id,
+        email: emailToDelete.email
       })
     })
 
@@ -717,6 +718,8 @@ export const handleDeleteEmail = async (id, setLoading, AdminEmails, setAdminEma
   } catch (error) {
     if (error.message === '400') {
       setError('Bad request.')
+    } else if (error.message === '409') {
+      setError('You cannot delete the email you are currently logged in with.')
     } else {
       setError('Unexpected error deleting email')
     }

--- a/frontend/src/utils/adminFetching.js
+++ b/frontend/src/utils/adminFetching.js
@@ -679,6 +679,8 @@ export const handleAddEmail = async (newEmail, setNewEmail, setAdminEmails, setL
       setError('Bad request.')
     } else if (error.message === '505') {
       setError('Email added for, but there was an error loading updated data. Please refresh this page.')
+    } else if (error.message === '409') {
+      setError('Could not add email. This user already exists (may be another admin, faculty, or student).')
     } else {
       setError('Unexpected error adding email.')
     }

--- a/frontend/src/utils/fetchDepartments.js
+++ b/frontend/src/utils/fetchDepartments.js
@@ -2,6 +2,8 @@
  * @file Function that calls the backend to retrieve and return a list of the departments.
  * A utility function to isolate its definition from UI-related code, and
  * because it is shared by several components.
+ * Note that a call to fetchDepartments() is equivalent to a call to getDataFrom(BACKEND_ENDPOINT).
+ * The helper function getDataFrom(…) was implemented later and the earlier fetch… functions were not refactored.
  *
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */

--- a/frontend/src/utils/fetchDisciplines.js
+++ b/frontend/src/utils/fetchDisciplines.js
@@ -2,6 +2,8 @@
  * @file Function that calls the backend to retrieve and return a list of the Diciplines.
  * A utility function to isolate its definition from UI-related code, and
  * because it is shared by several components.
+ * Note that a call to fetchDisciplines() is equivalent to a call to getDataFrom(BACKEND_ENDPOINT).
+ * The helper function getDataFrom(…) was implemented later and the earlier fetch… functions were not refactored.
  *
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */

--- a/frontend/src/utils/fetchMajors.js
+++ b/frontend/src/utils/fetchMajors.js
@@ -2,6 +2,8 @@
  * @file Function that calls the backend to retrieve and return a list of the majors.
  * A utility function to isolate its definition from UI-related code, and
  * because it is shared by several components.
+ * Note that a call to fetchMajors() is equivalent to a call to getDataFrom(BACKEND_ENDPOINT).
+ * The helper function getDataFrom(…) was implemented later and the earlier fetch… functions were not refactored.
  *
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */

--- a/frontend/src/utils/fetchResearchPeriods.js
+++ b/frontend/src/utils/fetchResearchPeriods.js
@@ -2,6 +2,8 @@
  * @file Function that calls the backend to retrieve and return a list of the research periods.
  * A utility function to isolate its definition from UI-related code, and
  * because it is shared by several components.
+ * Note that a call to fetchResearchPeriods() is equivalent to a call to getDataFrom(BACKEND_ENDPOINT).
+ * The helper function getDataFrom(…) was implemented later and the earlier fetch… functions were not refactored.
  *
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */

--- a/frontend/src/utils/fetchUmbrellaTopics.js
+++ b/frontend/src/utils/fetchUmbrellaTopics.js
@@ -2,6 +2,8 @@
  * @file Function that calls the backend to retrieve and return a list of the umbrella topics.
  * A utility function to isolate its definition from UI-related code, and
  * because it is shared by several components.
+ * Note that a call to fetchUmbrellaTopics() is equivalent to a call to getDataFrom(BACKEND_ENDPOINT).
+ * The helper function getDataFrom(…) was implemented later and the earlier fetch… functions were not refactored.
  *
  * @author Eduardo Perez Rocha
  */

--- a/frontend/src/utils/getDataFrom.js
+++ b/frontend/src/utils/getDataFrom.js
@@ -2,6 +2,8 @@
  * @file Function that calls the backend to retrieve and return data based on specified endpoint.
  * They are utility functions to isolate its definition from UI-related code
  * and because it is shared by several components.
+ * Note that a call to fetchDisciplines() is equivalent to a call to getDataFrom(BACKEND_ENDPOINT).
+ * The helper function getDataFrom(…) was implemented later and the earlier fetch… functions were not refactored.
  *
  * @author Natalie Jungquist <njungquist@sandiego.edu>
  */


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** Deleting an email was not working for admins. It was returning 404 because the backend endpoint was misconfigured in the backend.

To fix, I fixed the backend so that the ID of the admin users are returned to the frontend and then used to delete the admin from the database. I also added a check in the backend endpoint to make sure the user can't delete the email if it's the one they are currently logged in as. This prevents the admin from accidentally deleting the only admin email that exists, and accidentally logging themself out.

## UI/UX Implementation
The frontend now displays an error message of they try to delete the email they are currently logged in with.

## Model Updates
AdminEmailDTO now includes the id.

### Data Models
userService now handles deleteUserById.

### Object-Oriented Models
No changes

## End-to-End Testing Instructions
1. login as admin
2. go to manage app variables 
3. click admin emails
4. click on delete icons to delete